### PR TITLE
chore: GitHub ActionでCI/CDを設定するためにファイルを追加

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,16 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - master    # change to main if needed
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## 概要

GitHub Actionを利用しCI/CDを設定する

## 変更点

- fly tokenを生成
- GitHubのbagle_mapリポジトリの設定にtokenを紐づけ
- new file:   .github/workflows/fly.yml

## 影響範囲

- GitHub上のmasterブランチにpushされたとき自動でデプロイされるようになる

## 関連Issue

- 関連Issue: #50 