### PR TITLE
fix: localhostでapplication.cssが更新されないため、Docker、fly.ioの設定を修正

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,9 +30,11 @@ COPY . /myapp
 
 #bundle installを実行
 RUN bundle install
+RUN yarn install
 
-#assetsをプリコンパイル
-RUN bundle exec rails assets:precompile
+# アセットを先にビルドするか確認し、Fly.ioでのデプロイ時のみ実行
+ARG FLY_DEPLOY=false
+RUN if [ "$FLY_DEPLOY" = "true" ]; then bundle exec rails assets:precompile; fi
 
 #コンテナがリッスンするPORTを指定
 EXPOSE 3000

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0 -p 3000
 js: yarn build --watch
-css: yarn build:css --watch
+css: yarn watch:css

--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
+    command: bash -c "bundle exec rails db:prepare && rm -f tmp/pids/server.pid && bin/dev"
     tty: true
     stdin_open: true
     volumes:

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,8 @@ primary_region = 'nrt'
 
 [build]
   dockerfile = 'Dockerfile.dev'
+  [build.args]
+    FLY_DEPLOY = "true"
 
 [http_service]
   internal_port = 3000


### PR DESCRIPTION
## 概要

localhostでapplication.cssが更新されないため、Docker、fly.ioの設定を修正

## 変更点

- modified:   Dockerfile.dev
  - fly.ioデプロイ時のみassets:precompileされるように設定
- modified:   Procfile.dev
  - `css: yarn watch:css`に変更
- modified:   compose.yml
  - `webのcommandを修正
- modified:   fly.toml
  - buildの設定を追記

## 影響範囲

localhostではapplication.cssが自動更新、デプロイ環境ではデプロイ時にassets:precompileを実行

## 関連Issue

- 関連Issue: #55 