### PR TITLE
add: Google Map APIから取得したデータを保存するため、BagelShopモデル、Bagelshopテーブルを作成

### DIFF
--- a/app/models/bagel_shop.rb
+++ b/app/models/bagel_shop.rb
@@ -1,0 +1,3 @@
+class BagelShop < ApplicationRecord
+  validates :name, :latitude, :longitude, :place_id, presence: true, uniqueness: true
+end

--- a/db/migrate/20240814070506_create_bagel_shops.rb
+++ b/db/migrate/20240814070506_create_bagel_shops.rb
@@ -1,0 +1,20 @@
+class CreateBagelShops < ActiveRecord::Migration[7.1]
+  def change
+    create_table :bagel_shops do |t|
+      t.string :name, null: false
+      t.string :address
+      t.float :latitude, null: false
+      t.float :longitude, null: false
+      t.string :place_id, null: false
+      t.string :opening_hours
+      t.string :photo_reference
+      t.float :rating
+      t.integer :user_ratings_total
+      t.string :website
+      t.string :formatted_phone_number
+      t.datetime :last_updated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_070506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bagel_shops", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address"
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.string "place_id", null: false
+    t.string "opening_hours"
+    t.string "photo_reference"
+    t.float "rating"
+    t.integer "user_ratings_total"
+    t.string "website"
+    t.string "formatted_phone_number"
+    t.datetime "last_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/test/fixtures/bagel_shops.yml
+++ b/test/fixtures/bagel_shops.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/bagel_shop_test.rb
+++ b/test/models/bagel_shop_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BagelShopTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

Google Map APIから取得したデータを保存するため、BagelShopモデル、Bagelshopテーブルを作成

## 変更点

- new file:   app/models/bagel_shop.rb
  - validates: presence, uniqueness
- new file:   db/migrate/20240814070506_create_bagel_shops.rb
  - culumn: name, address, latitude, longitude, place_id, opening_hours, photo_reference, rating, user_ratings_total, website, formatted_phone_number, last_updated_at
- modified:   db/schema.rb
- new file:   test/fixtures/bagel_shops.yml
- new file:   test/models/bagel_shop_test.rb

## テスト

rails c で入力し確認

## 関連Issue

- 関連Issue: #19 