### PR TITLE
fix: デプロイ環境でMigrations are pendingエラーが発生したので、デプロイ時にMigrationされるように設定を変更

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -34,7 +34,9 @@ RUN yarn install
 
 # アセットを先にビルドするか確認し、Fly.ioでのデプロイ時のみ実行
 ARG FLY_DEPLOY=false
-RUN if [ "$FLY_DEPLOY" = "true" ]; then bundle exec rails assets:precompile; fi
+RUN if [ "$FLY_DEPLOY" = "true" ]; then \
+      bundle exec rails assets:precompile; \
+    fi
 
 #コンテナがリッスンするPORTを指定
 EXPOSE 3000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,5 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-  config.hosts << "bagle-map.fly.dev"
+  config.hosts << "bagel-map.fly.dev"
 end

--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,9 @@
-# fly.toml app configuration file generated for bagle-map on 2024-07-29T16:23:37+09:00
+# fly.toml app configuration file generated for bagel-map on 2024-08-15T15:08:19+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'bagle-map'
+app = 'bagel-map'
 primary_region = 'nrt'
 
 [build]
@@ -21,3 +21,6 @@ primary_region = 'nrt'
 
 [[vm]]
   size = 'shared-cpu-1x'
+
+[deploy]
+  release_command = './bin/rails db:prepare'


### PR DESCRIPTION
## 概要

デプロイ環境でMigrations are pendingエラーが発生したため、デプロイ時にMigrationされるように`rails db:prepare`を設定

## 変更点

- modified:   Dockerfile.dev
  - コードの体裁を修正
- modified:   config/environments/development.rb
  - config.hosts << "bagel-map.fly.dev"に修正
- modified:   fly.toml
  - release_command = './bin/rails db:prepare'の追記

## テスト

- 手動でデプロイを実施し完了を確認
- アプリのURLにアクセスしTOPページが表示されることを確認

## 関連Issue

- 関連Issue: #61 