### PR TITLE
add: Google Maps APIを使って、Googleマップを作成し表示

### DIFF
--- a/app/controllers/bagel_shops_controller.rb
+++ b/app/controllers/bagel_shops_controller.rb
@@ -1,0 +1,5 @@
+class BagelShopsController < ApplicationController
+  def index
+    # @bagel_shops = BagelShop.all
+  end
+end

--- a/app/helpers/bagel_shops_helper.rb
+++ b/app/helpers/bagel_shops_helper.rb
@@ -1,0 +1,2 @@
+module BagelShopsHelper
+end

--- a/app/views/bagel_shops/index.html.erb
+++ b/app/views/bagel_shops/index.html.erb
@@ -1,0 +1,54 @@
+<h2>gmap</h2>
+
+<input id="address" type="textbox" value="GeekSalon">
+<input type="button" value="Encode" onclick="codeAddress()">
+<div id="display">何かが表示される、、、、！</div>
+
+<div id='map'></div>
+
+<style>
+#map {
+  height: 600px;
+  width: 600px;
+}
+</style>
+
+<script>
+let map
+let geocoder
+const display = document.getElementById('display')
+
+function initMap(){
+  geocoder = new google.maps.Geocoder()
+
+  map = new google.maps.Map(document.getElementById('map'), {
+    center: {lat: 35.68123620000001, lng: 139.7671248},
+    zoom: 15,
+  });
+
+  marker = new google.maps.Marker({
+    position:  {lat: 35.68123620000001, lng: 139.7671248},
+    map: map
+  });
+}
+
+
+function codeAddress(){
+  let inputAddress = document.getElementById('address').value;
+
+  geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+    if (status == 'OK') {
+      map.setCenter(results[0].geometry.location);
+      var marker = new google.maps.Marker({
+          map: map,
+          position: results[0].geometry.location
+      });
+      display.textContent = "検索結果：" + results[ 0 ].geometry.location
+    } else {
+      alert('該当する結果がありませんでした：' + status);
+    }
+  });
+}
+
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GMAPS_API_KEY'] %>&callback=initMap" async defer></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root 'static_pages#top'
+  resources :bagel_shops, only: %i[index]
 end

--- a/test/controllers/bagel_shops_controller_test.rb
+++ b/test/controllers/bagel_shops_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BagelShopsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

Google Maps APIを使って、bagel_shops/indexにGoogleマップを作成し表示

## 変更点

- new file:   app/controllers/bagel_shops_controller.rb
  - index
- new file:   app/helpers/bagel_shops_helper.rb
- new file:   app/views/bagel_shops/index.html.erb
  - Google Mapの表示
  - 座標表示
  - 検索フォーム
- modified:   config/routes.rb
  - resources :bagel_shops, only: %i[index]
- new file:   test/controllers/bagel_shops_controller_test.rb

## テスト

- localhostで表示を確認

## 関連Issue

- 関連Issue: #26 