### PR TITLE
add: 店舗情報を元に地図上にピンを指して表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 gem "dotenv-rails"
 gem 'google_places'
+gem 'gon'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,11 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     google_places (2.0.0)
       httparty (>= 0.13.1)
     httparty (0.22.0)
@@ -141,6 +146,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -216,6 +222,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.3.2)
       strscan
     rubyzip (2.3.2)
@@ -272,6 +280,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  gon
   google_places
   jbuilder
   jsbundling-rails

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,3 +1,4 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
 @import 'top';
+@import 'map';

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -1,0 +1,20 @@
+.custom-map-control-button {
+  background-color: white;
+  border: none;
+  outline: none;
+  width: 40px;
+  height: 40px;
+  border-radius:5%;
+  box-shadow: 0 2px 6px rgba(0,0,0,.3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 10px;
+  margin-top: 10px;
+}
+
+.custom-map-control-button i {
+  font-size: 25px; /* アイコンサイズ */
+  color: gray; /* アイコンカラー */
+}

--- a/app/controllers/bagel_shops_controller.rb
+++ b/app/controllers/bagel_shops_controller.rb
@@ -2,5 +2,6 @@ class BagelShopsController < ApplicationController
   def index
     @bagel_shops = BagelShop.all
     gon.bagel_shops = @bagel_shops
+    gon.api_key = ENV["GMAPS_API_KEY"]
   end
 end

--- a/app/controllers/bagel_shops_controller.rb
+++ b/app/controllers/bagel_shops_controller.rb
@@ -1,5 +1,6 @@
 class BagelShopsController < ApplicationController
   def index
-    # @bagel_shops = BagelShop.all
+    @bagel_shops = BagelShop.all
+    gon.bagel_shops = @bagel_shops
   end
 end

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -7,13 +7,38 @@ function initMap() {
   geocoder = new google.maps.Geocoder();
 
   map = new google.maps.Map(document.getElementById("map"), {
-    center: { lat: 35.68123620000001, lng: 139.7671248 },
+    center: { lat: 35.68123620000001, lng: 139.7671248 }, //東京駅
     zoom: 15,
   });
   infoWindow = new google.maps.InfoWindow();
 
-  const locationButton = document.createElement("button");
+  // Railsから保存された店舗情報を取得して地図上にマーカーを表示
+  const bagelShops = gon.bagel_shops;
+  bagelShops.forEach(function (shop) {
+    let markerLatLng = { lat: shop.latitude, lng: shop.longitude }; // 緯度経度のデータ作成
+    let marker = new google.maps.Marker({
+      position: markerLatLng,
+      map: map,
+    });
 
+    // マーカーをクリックしたとき、詳細情報を表示
+    let infowindow = new google.maps.InfoWindow({
+      position: markerLatLng,
+      content:
+        "<a href='/bagel_shops/" +
+        shop.id +
+        "' target='_blank'>" +
+        shop.body +
+        "</a>",
+    }); // 詳細ページへのリンクを表示
+
+    marker.addListener("click", function () {
+      infowindow.open(map, marker);
+    });
+  });
+
+  // 現在地を取得して表示
+  const locationButton = document.createElement("button");
   locationButton.textContent = "Pan to Current Location";
   locationButton.classList.add("custom-map-control-button");
   map.controls[google.maps.ControlPosition.TOP_CENTER].push(locationButton);
@@ -61,6 +86,7 @@ function initMap() {
   markers.push(marker);
 }
 
+// 地図検索する関数
 function codeAddress() {
   let inputAddress = document.getElementById("address").value;
 
@@ -93,6 +119,7 @@ function clearMarkers() {
   markers = []; // 配列をクリア
 }
 
+// infoWindowのエラーメッセージを出力する関数
 function handleLocationError(browserHasGeolocation, infoWindow, pos) {
   infoWindow.setPosition(pos);
   infoWindow.setContent(

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,19 +1,49 @@
-let map, geocoder, infoWindow;
+let map, geocoder;
 let markers = [];
+const apiKey = gon.api_key
 
+const defaultLocation = { lat: 35.68123620000001, lng: 139.7671248 };
+const bagelShops = gon.bagel_shops;
 const display = document.getElementById("display");
 
 function initMap() {
   geocoder = new google.maps.Geocoder();
+  const mapElement = document.getElementById("map");
+  if (!mapElement) {
+    console.error("Map element not found.");
+    return;
+  }
 
+  // 初期位置の設定
+  showCurrentLocation();
   map = new google.maps.Map(document.getElementById("map"), {
-    center: { lat: 35.68123620000001, lng: 139.7671248 }, //東京駅
+    center: { lat: defaultLocation.lat, lng: defaultLocation.lng }, //東京駅
     zoom: 15,
+    streetViewControl: false, // ストリートビューのボタン非表示
+    mapTypeControl: false, // 地図、航空写真のボタン非表示
+    fullscreenControl: false, // フルスクリーンボタン非表示
   });
-  infoWindow = new google.maps.InfoWindow();
+
+  // センターピンの表示
+  centerPin = new google.maps.Marker({
+    map: map,
+    draggable: true,
+    position: map.getCenter(), // 初期位置をマップの中心に設定
+    title: "現在地",
+  });
+
+  // マップのドラッグ終了イベント
+  map.addListener("dragend", function () {
+    centerPin.setPosition(map.getCenter());
+  });
+
+  // infoWindowを作成
+  let infoWindow = new google.maps.InfoWindow({
+    pixelOffset: new google.maps.Size(0, -50),
+    maxWidth: 300
+  });
 
   // Railsから保存された店舗情報を取得して地図上にマーカーを表示
-  const bagelShops = gon.bagel_shops;
   bagelShops.forEach(function (shop) {
     let markerLatLng = { lat: shop.latitude, lng: shop.longitude }; // 緯度経度のデータ作成
     let marker = new google.maps.Marker({
@@ -21,28 +51,124 @@ function initMap() {
       map: map,
     });
 
-    // マーカーをクリックしたとき、詳細情報を表示
-    let infowindow = new google.maps.InfoWindow({
-      position: markerLatLng,
-      content:
-        "<a href='/bagel_shops/" +
-        shop.id +
-        "' target='_blank'>" +
-        shop.body +
-        "</a>",
-    }); // 詳細ページへのリンクを表示
-
+    // マーカーがクリックされたときに情報ウィンドウを表示
     marker.addListener("click", function () {
-      infowindow.open(map, marker);
+      // photo_referenceをカンマで分割して最初の画像を使用
+      if (shop.photo_references) { // 画像がある場合
+        const photoReferences = shop.photo_references.split(",");
+        const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReferences[0]}&key=${apiKey}`;
+
+        // infoWindowの内容を更新
+        infoWindow.setContent(`
+        <div class="custom-info">
+          <div class="custom-info-item photo">
+            <img src="${photoUrl}" alt="${
+          shop.name
+        }" style="width:100%;height:auto;">
+          </div>
+          <div class="custom-info-item name">${shop.name}</div>
+          <div class="custom-info-item address">${shop.address}</div>
+          <div class="custom-info-item rating">⭐${
+            shop.rating ? shop.rating : "評価なし"
+          }</div>
+          <div class="custom-info-item link_to_detail">
+            <a href=bagel_shop_path(${shop.id}) target="_blank">店舗詳細</a>
+          </div>
+        </div>
+        `);
+      } else { // 画像がない場合
+        // infoWindowの内容を更新
+        infoWindow.setContent(`
+        <div class="custom-info">
+          <div class="custom-info-item name">${shop.name}</div>
+          <div class="custom-info-item address">${shop.address}</div>
+          <div class="custom-info-item rating">⭐${
+            shop.rating ? shop.rating : "評価なし"
+          }</div>
+          <div class="custom-info-item link_to_detail">
+            <a href=bagel_shop_path(${shop.id}) target="_blank">店舗詳細</a>
+          </div>
+        </div>
+        `);
+      };
+
+
+      // infoWindowを指定したマーカーの位置に表示
+      infoWindow.open(map, marker);
     });
   });
 
-  // 現在地を取得して表示
+  // ボタンを押すとshowCurrentLocation関数で現在地を取得して表示
   const locationButton = document.createElement("button");
-  locationButton.textContent = "Pan to Current Location";
+  locationButton.innerHTML = '<i class="fa-solid fa-location-crosshairs"></i>';
   locationButton.classList.add("custom-map-control-button");
-  map.controls[google.maps.ControlPosition.TOP_CENTER].push(locationButton);
-  locationButton.addEventListener("click", () => {
+  map.controls[google.maps.ControlPosition.TOP_RIGHT].push(locationButton);
+  locationButton.addEventListener("click", showCurrentLocation);
+}
+
+  // 地図検索
+  window.codeAddress = function () {
+    let inputAddress = document.getElementById("address").value;
+
+    geocoder.geocode({ address: inputAddress }, function (results, status) {
+      if (status == "OK") {
+        // マーカーを作成
+        map.setCenter(results[0].geometry.location);
+
+        // マーカーを追加する前に既存のマーカーをクリア
+        clearMarkers();
+
+        var marker = new google.maps.Marker({
+          map: map,
+          position: results[0].geometry.location,
+        });
+        markers.push(marker); // マーカーを配列に追加
+
+        display.textContent = "検索結果：" + results[0].geometry.location;
+      } else {
+        alert("該当する結果がありませんでした：" + status);
+      }
+    });
+  };
+
+  // 既存のマーカーをすべて消去する関数
+  function clearMarkers() {
+    for (let i = 0; i < markers.length; i++) {
+      markers[i].setMap(null);
+    }
+    markers = []; // 配列をクリア
+  }
+
+  // infoWindowのエラーメッセージを出力する関数
+  function handleLocationError(browserHasGeolocation, infoWindow, pos) {
+    infoWindow.setPosition(pos);
+    infoWindow.setContent(
+      browserHasGeolocation
+        ? "Error: 現在地を取得できませんでした"
+        : "Error: このブラウザはGeolocationをサポートしていません"
+    );
+    infoWindow.open(map);
+  }
+
+  // 現在地の緯度と経度を取得する関数
+  function getCurrentLocation(){
+    // Try HTML5 geolocation.
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const pos = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          }
+        });
+      } else {
+        // Browser doesn't support Geolocation
+        handleLocationError(false, infoWindow, map.getCenter());
+      }
+    }
+
+  // 現在地を取得して表示する関数
+  function showCurrentLocation(){
     // Try HTML5 geolocation.
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
@@ -52,20 +178,20 @@ function initMap() {
             lng: position.coords.longitude,
           };
 
-          infoWindow.setPosition(pos);
-          infoWindow.setContent("Location found.");
-          infoWindow.open(map);
+          // infoWindow.setPosition(pos);
+          // infoWindow.setContent("Location found.");
+          // infoWindow.open(map);
           map.setCenter(pos);
 
           // マーカーを追加する前に既存のマーカーをクリア
-          clearMarkers();
+          // clearMarkers();
 
-          // 現在地にマーカーを立てる
-          var marker = new google.maps.Marker({
-            map: map,
+          // 現在地にマーカーを移動させる
+          centerPin = new google.maps.Marker({
             position: pos,
+            map: map,
           });
-          markers.push(marker); // マーカーを配列に追加
+          // markers.push(marker); // マーカーを配列に追加
         },
         () => {
           handleLocationError(true, infoWindow, map.getCenter());
@@ -75,59 +201,6 @@ function initMap() {
       // Browser doesn't support Geolocation
       handleLocationError(false, infoWindow, map.getCenter());
     }
-  });
-
-  // 初期位置のマーカーもクリアしてから追加
-  clearMarkers();
-  const marker = new google.maps.Marker({
-    position: { lat: 35.68123620000001, lng: 139.7671248 },
-    map: map,
-  });
-  markers.push(marker);
-}
-
-// 地図検索する関数
-function codeAddress() {
-  let inputAddress = document.getElementById("address").value;
-
-  geocoder.geocode({ address: inputAddress }, function (results, status) {
-    if (status == "OK") {
-      // マーカーを作成
-      map.setCenter(results[0].geometry.location);
-
-      // マーカーを追加する前に既存のマーカーをクリア
-      clearMarkers();
-
-      var marker = new google.maps.Marker({
-        map: map,
-        position: results[0].geometry.location,
-      });
-      markers.push(marker); // マーカーを配列に追加
-
-      display.textContent = "検索結果：" + results[0].geometry.location;
-    } else {
-      alert("該当する結果がありませんでした：" + status);
-    }
-  });
-}
-
-// 既存のマーカーをすべて消去する関数
-function clearMarkers() {
-  for (let i = 0; i < markers.length; i++) {
-    markers[i].setMap(null);
   }
-  markers = []; // 配列をクリア
-}
 
-// infoWindowのエラーメッセージを出力する関数
-function handleLocationError(browserHasGeolocation, infoWindow, pos) {
-  infoWindow.setPosition(pos);
-  infoWindow.setContent(
-    browserHasGeolocation
-      ? "Error: The Geolocation service failed."
-      : "Error: Your browser doesn't support geolocation."
-  );
-  infoWindow.open(map);
-}
-
-window.initMap = initMap;
+  window.initMap = initMap;

--- a/app/views/bagel_shops/index.html.erb
+++ b/app/views/bagel_shops/index.html.erb
@@ -1,8 +1,10 @@
-<h2>gmap</h2>
-
-<input id="address" type="textbox" value="GeekSalon">
+<%
+=begin%>
+ <input id="address" type="textbox" value="GeekSalon">
 <input type="button" value="Encode" onclick="codeAddress()">
-<div id="display">何かが表示される、、、、！</div>
+<div id="display">何かが表示される、、、、！</div> 
+<%
+=end%>
 
 <div id="map" style="height:700px; width:100%;"></div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= include_gon %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= include_gon %>
+    <script src="https://kit.fontawesome.com/69f6ba74fd.js" crossorigin="anonymous"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,7 +3,7 @@
     <div class="mb-5">
       <h4>ベーグル食べたくありませんか?</h4>
     </div>
-    <%= link_to "現在地付近のお店を探す", '/', class: 'btn btn-custom btn-lg p-3' %>
+    <%= link_to "現在地付近のお店を探す", bagel_shops_path, class: 'btn btn-custom btn-lg p-3' %>
     <p class="fs-6">このアプリは身近のベーグル専門店を探すアプリです</p>
   </div>
 </div>


### PR DESCRIPTION
## 概要

BagelShopテーブルの店舗情報を元に地図上にピンを指して表示

## 変更点

- modified:   Gemfile
  - gem 'gon'
- modified:   Gemfile.lock
- modified:   app/assets/stylesheets/application.bootstrap.scss
- new file:   app/assets/stylesheets/map.scss
  - custom-map-control-button: 現在地取得ボタン
- modified:   app/controllers/bagel_shops_controller.rb
  - BagelShopテーブルのデータ取得
  - gonを使ってJavaScriptにデータを受け渡し
- modified:   app/javascript/gmap.js
  - 画面遷移後、現在地を取得
  - センターピンを表示
  - 店舗のピンを表示
  - 店舗の情報ウィンドウを表示
- modified:   app/views/bagel_shops/index.html.erb
- modified:   app/views/layouts/application.html.erb
  - gonをinclude
- modified:   app/views/static_pages/top.html.erb
  - ボタンの遷移先を記載

## テスト

- localhostで表示を確認

## 関連Issue

- 関連Issue: #23 