### PR TITLE
fix: デプロイ環境のデータベースを指定するURLを追記

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -86,3 +86,4 @@ production:
   database: myapp_production
   username: myapp
   password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
## 概要

デプロイ環境でrakeファイルを実行したがエラーで停止してしまうため、データベースの設定を変更

![image](https://github.com/user-attachments/assets/ed4263d3-1003-4c79-8c3a-71da938babc7)


## 変更点

- modified:   config/database.yml
  - url: <%= ENV['DATABASE_URL'] %>をproductionに追記
- fly.ioで環境変数を設定
  - DB_USERNAME
  - DB_PASSWORD
  - DB_HOST
  - DB_PORT
  - RAILS_MASTER_KEY
- サーバーがクラッシュするためfly.ioのサーバースペックを変更
  
![image](https://github.com/user-attachments/assets/e476052d-9e26-42c0-af84-3b178356ca0e)

  - 変更前：

    | NAME | COUNT | KIND | CPUS | MEMORY | REGIONS |
    |:---:|:---:|:---:|:---:|:---:|:---:|
    | app | 2 | shared | 1 | 256 MB | nrt(2) |
  - 変更後：

    | NAME | COUNT | KIND | CPUS | MEMORY | REGIONS |
    |:---:|:---:|:---:|:---:|:---:|:---:|
    | app | 2 | shared | 2 | 512 MB | nrt(2) |

## 影響範囲

fly.ioの設定変更のため課金可能性あり

## テスト

- デプロイ環境にてrakeファイルを実行し、アプリに反映されるのを確認

## 関連Issue

- 関連Issue: #67 

## 参考資料

- [https://qiita.com/lemonade_37/items/73dd5a060ad8ff953d10](url)
- [https://zenn.dev/counterworks/articles/c68fc79896889f#4.%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A](url)
- [https://fly.io/docs/rails/the-basics/configuration/#encrypted-credentials-file](url)