### PR TITLE
fix: 地図上の情報ウィンドウからリンクで店舗詳細ページに遷移ず、ブラウザバック後の表示がおかしかったため、リンクと画面遷移の設定を修正

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,6 +1,6 @@
-let map, geocoder;
+let map, geocoder, centerPin, infoWindow;
 let markers = [];
-const apiKey = gon.api_key
+const apiKey = gon.api_key;
 
 const defaultLocation = { lat: 35.68123620000001, lng: 139.7671248 };
 const bagelShops = gon.bagel_shops;
@@ -38,7 +38,7 @@ function initMap() {
   });
 
   // infoWindowを作成
-  let infoWindow = new google.maps.InfoWindow({
+  infoWindow = new google.maps.InfoWindow({
     pixelOffset: new google.maps.Size(0, -50),
     maxWidth: 300
   });
@@ -62,17 +62,13 @@ function initMap() {
         infoWindow.setContent(`
         <div class="custom-info">
           <div class="custom-info-item photo">
-            <img src="${photoUrl}" alt="${
-          shop.name
-        }" style="width:100%;height:auto;">
+            <img src="${photoUrl}" alt="${shop.name}" style="width:100%;height:auto;">
           </div>
           <div class="custom-info-item name">${shop.name}</div>
           <div class="custom-info-item address">${shop.address}</div>
-          <div class="custom-info-item rating">⭐${
-            shop.rating ? shop.rating : "評価なし"
-          }</div>
+          <div class="custom-info-item rating">⭐${shop.rating ? shop.rating : "評価なし"}</div>
           <div class="custom-info-item link_to_detail">
-            <a href=bagel_shop_path(${shop.id}) target="_blank">店舗詳細</a>
+            <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
           </div>
         </div>
         `);
@@ -82,11 +78,10 @@ function initMap() {
         <div class="custom-info">
           <div class="custom-info-item name">${shop.name}</div>
           <div class="custom-info-item address">${shop.address}</div>
-          <div class="custom-info-item rating">⭐${
-            shop.rating ? shop.rating : "評価なし"
+          <div class="custom-info-item rating">⭐${shop.rating ? shop.rating : "評価なし"
           }</div>
           <div class="custom-info-item link_to_detail">
-            <a href=bagel_shop_path(${shop.id}) target="_blank">店舗詳細</a>
+            <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
           </div>
         </div>
         `);
@@ -150,23 +145,6 @@ function initMap() {
     infoWindow.open(map);
   }
 
-  // 現在地の緯度と経度を取得する関数
-  function getCurrentLocation(){
-    // Try HTML5 geolocation.
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          const pos = {
-            lat: position.coords.latitude,
-            lng: position.coords.longitude,
-          }
-        });
-      } else {
-        // Browser doesn't support Geolocation
-        handleLocationError(false, infoWindow, map.getCenter());
-      }
-    }
-
   // 現在地を取得して表示する関数
   function showCurrentLocation(){
     // Try HTML5 geolocation.
@@ -178,20 +156,12 @@ function initMap() {
             lng: position.coords.longitude,
           };
 
-          // infoWindow.setPosition(pos);
-          // infoWindow.setContent("Location found.");
-          // infoWindow.open(map);
           map.setCenter(pos);
 
-          // マーカーを追加する前に既存のマーカーをクリア
-          // clearMarkers();
-
           // 現在地にマーカーを移動させる
-          centerPin = new google.maps.Marker({
-            position: pos,
-            map: map,
-          });
-          // markers.push(marker); // マーカーを配列に追加
+          if (centerPin) {
+            centerPin.setPosition(pos);
+          }
         },
         () => {
           handleLocationError(true, infoWindow, map.getCenter());
@@ -204,3 +174,8 @@ function initMap() {
   }
 
   window.initMap = initMap;
+
+  window.addEventListener("popstate", function (e) {
+    window.location.reload();
+    console.log("Reload!");
+  });

--- a/app/views/bagel_shops/index.html.erb
+++ b/app/views/bagel_shops/index.html.erb
@@ -1,5 +1,6 @@
 <%= javascript_include_tag "gmap" %>
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GMAPS_API_KEY'] %>&callback=initMap" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GMAPS_API_KEY'] %>&callback=initMap" async defer>
+</script>
 
 <%#
 <input id="address" type="textbox" value="GeekSalon">
@@ -8,7 +9,7 @@
 %>
 
 <div class="contaner m-3 pb-3 border-bottom border-3">
-  <div id="map" style="height:700px; width:100%;"></div>
+  <div id="map" style="height:600px; width:100%;"></div>
 </div>
 <div class="contaner m-3">
   <h2 class="mb-3 pb-3 border-bottom border-3"><%= t('.title') %></h2>

--- a/app/views/bagel_shops/show.html.erb
+++ b/app/views/bagel_shops/show.html.erb
@@ -8,7 +8,7 @@
 
       <div class="card mb-4">
         <% if @bagel_shop.photo_references.present? %>
-          <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=#{@bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: @bagel_shop.name, size: "400x400", class: "card-img-top", style: "object-fit: cover;" %>
+          <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=#{@bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: @bagel_shop.name, size: "400x400", class: "card-img-top", style: "object-fit: cover;" %>
         <% else %>
           <%= image_tag "bagel_shop_placeholder.jpg", class: "card-img-top", width: "400", height: "400", style: "object-fit: cover;" %>
         <% end %>


### PR DESCRIPTION
## 概要

地図上の情報ウィンドウからリンクで店舗詳細ページに遷移ず、ブラウザバック後に地図の店舗ピンが消えてしまうため、リンクと画面遷移の設定を修正

## 変更点

- modified:   app/javascript/gmap.js
  - 変数、関数の追加・削除
  - 強制リロードイベントの追加
- modified:   app/views/bagel_shops/index.html.erb
- modified:   app/views/bagel_shops/show.html.erb

## 影響範囲

ブラウザバック後、店舗ピンが正常に表示
地図の情報ウィンドウから正常に店舗詳細へ遷移

## テスト

- localhostで正常に表示されるのを確認

## 関連Issue

- 関連Issue: #71 