### PR TITLE
add: お問い合わせフォームをGoogleフォームで作成し、お問い合わせページへのリンク作成

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -60,6 +60,6 @@
 
 .link_text {
   text-decoration: none;
-  color: whitesmoke;
+  color: #595959;
   cursor: pointer; /* カーソルをポインターにする */
 }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,15 +4,11 @@
       <div class='col'>
         <p class='m-1'>© 2024 BAGEL MAP</p>
       </div>
-      <%
-=begin%>
- <div class='col text-end'>
-        <%= link_to '利用規約', '#', class: 'link_text me-5' %>
-        <%= link_to 'プライバシー・ポリシー', '#', class: 'link_text me-5' %>
-        <%= link_to 'お問い合わせ', '#', class: 'link_text' %>
-      </div> 
-<%
-=end%>
+      <div class='col text-end'>
+        <%= link_to '利用規約', terms_of_use_path, class: 'link_text me-5' %>
+        <%= link_to 'プライバシー・ポリシー', privacy_policy_path, class: 'link_text me-5' %>
+        <%= link_to 'お問い合わせ', 'https://forms.gle/wbYBH7aVzKSNTFGx9', target: :_blank, rel: "noopener noreferrer", class: 'link_text' %>
+      </div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## 概要

お問い合わせフォームをGoogleフォームで作成し、フッターからお問い合わせページへ遷移するリンクを表示

## 変更点

- modified:   app/assets/stylesheets/top.scss
  - リンクのスタイル調整
- modified:   app/views/shared/_footer.html.erb
  - リンクの表示（利用規約、プライバシー・ポリシー、お問い合わせ）

## 影響範囲

## テスト

- localhostで画面表示と画面遷移を確認

## 関連Issue

- 関連Issue: #29 