### PR TITLE
add: 検索フォームの入力に応じてフラッシュメッセージを表示＋dockerバージョンアップに伴うcompose.ymlの調整

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,21 @@
 class ApplicationController < ActionController::Base
   before_action :set_search
+  add_flash_types :success, :info, :warning, :danger
 
   def set_search
     @q = BagelShop.ransack(params[:q])
     @bagel_shops = @q.result(distinct: true).page(params[:page])
-    gon.search_bagel_shops = @bagel_shops
+
+    return unless params[:search_button]
+
+    if params[:q].present? && params[:q][:address_or_name_cont].blank?
+      flash[:warning] = '検索ワードが入力されていません'
+      redirect_back(fallback_location: root_path)
+    elsif @bagel_shops.empty?
+      flash[:warning] = '検索結果が見つかりませんでした'
+      redirect_back(fallback_location: root_path)
+    end
+
+    gon.search_bagel_shops = @bagel_shops if params[:q].present?
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,21 +1,28 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= page_title(yield(:title)) %></title>
-    <%= favicon_link_tag('favicon.png') %>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= include_gon %>
-    <script src="https://kit.fontawesome.com/69f6ba74fd.js" crossorigin="anonymous"></script>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-  </head>
+<head>
+  <title><%= page_title(yield(:title)) %></title>
+  <%= favicon_link_tag('favicon.png') %>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 
-  <body>
-    <%= render 'shared/header' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
-  </body>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <%= include_gon %>
+  <script src="https://kit.fontawesome.com/69f6ba74fd.js" crossorigin="anonymous"></script>
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+</head>
+
+<body>
+  <%= render 'shared/header' %>
+
+  <div id='flash-messages'>
+    <%= render 'shared/flash_messages' %>
+  </div>
+
+  <%= yield %>
+  <%= render 'shared/footer' %>
+</body>
+
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+<div class="alert alert-<%= message_type %> m-0">
+  <%= message %>
+</div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
 
     <!-- WEBアプリロゴ -->
     <%= link_to '/', class: 'navbar-brand ms-3' do %>
-      <%= image_tag 'logo.png' %>
+    <%= image_tag 'logo.png' %>
     <% end %>
 
     <!-- 検索フォーム -->
@@ -13,9 +13,8 @@
 
     <%
 =begin%>
- <!-- トグルボタンの設定 -->
-    <button class='navbar-toggler' data-bs-toggle='collapse' data-bs-target='#navbarSupportedContent'
-      aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
+    <!-- トグルボタンの設定 -->
+    <button class='navbar-toggler' data-bs-toggle='collapse' data-bs-target='#navbarSupportedContent' aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
       <span class='navbar-toggler-icon'></span>
     </button>
 
@@ -31,8 +30,8 @@
           <%= link_to 'ログイン', '/', class: 'nav-link btn btn-reverse me-3' %>
         </li>
       </ul>
-    </div> 
-<%
+    </div>
+    <%
 =end%>
   </nav>
 </header>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -2,14 +2,15 @@
   <!-- 検索フォーム -->
   <div class="search-form-container">
     <%= search_form_for @q, url: bagel_shops_path do |f| %>
-      <div class="input-group">
-        <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名や地名で検索", id: 'name_or_address' %>
-        <div class="input-group-append">
-          <%= f.submit class: 'btn btn-primary' %>
-        </div>
+    <div class="input-group">
+      <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
+      <div class="input-group-append">
+        <%= button_tag type: 'submit', class: 'btn btn-primary', name: 'search_button' do %>
+        <i class="fa-solid fa-magnifying-glass" style="color: #ede8e2;"></i>
+        <% end %>
       </div>
+    </div>
     <% end %>
-    <div id="display">何かが表示される、、、、！</div>
   </div>
 
   <!-- ソート

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       TZ: Asia/Tokyo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   resources :bagel_shops, only: %i[index show]
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_use', to: 'static_pages#terms_of_use'
+  get 'search', to: 'application#set_search'
 end


### PR DESCRIPTION
## 概要

検索フォームの入力に応じてフラッシュメッセージを表示し、dockerバージョンアップに伴いcompose.ymlを調整

## 変更点

- modified:   app/controllers/application_controller.rb
  - set_searchメソッドに条件分岐の追記
- modified:   app/views/layouts/application.html.erb
  - フラッシュメッセージの出力箇所追記
- new file:   app/views/shared/_flash_messages.html.erb
  - フラッシュメッセージを表示するパーシャル
- modified:   app/views/shared/_header.html.erb
- modified:   app/views/shared/_search_form.html.erb
  - 検索ボタンをアイコンに変更
- modified:   compose.yml
  - postgreSQL ver17(デフォルト) -> postgreSQL ver16を指定するように変更
- modified:   config/routes.rb
  - 検索時にset_searchメソッドを適用するようにルートを指定

## 影響範囲

## テスト

- localhostにてフラッシュメッセージの表示を確認

## 関連Issue

- 関連Issue: #88 