### PR TITLE
hotfix: gmap.js内のコード修正 + 同じワードで再検索した際に前回検索の結果が表示される現象を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,14 @@ class ApplicationController < ActionController::Base
     @q = BagelShop.ransack(params[:q])
     @bagel_shops = @q.result(distinct: true).page(params[:page])
 
+    if params[:q].present?
+      # gonのキャッシュを防ぐため、明示的にリセット
+      gon.clear
+      gon.search_bagel_shops = @bagel_shops
+    end
+
+    puts "gon.search_bagel_shops: #{@bagel_shops.inspect}"
+
     return unless params[:search_button]
 
     if params[:q].present? && params[:q][:address_or_name_cont].blank?
@@ -15,7 +23,5 @@ class ApplicationController < ActionController::Base
       flash[:warning] = '検索結果が見つかりませんでした'
       redirect_back(fallback_location: root_path)
     end
-
-    gon.search_bagel_shops = @bagel_shops if params[:q].present?
   end
 end

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,4 +1,4 @@
-let map, geocoder, centerPin, infoWindow, lastCenter;
+let map, geocoder, centerPin, infoWindow, lastCenter, bagelShops, searchBagelShops;
 let markers = [];
 const apiKey = gon.api_key;
 
@@ -7,12 +7,24 @@ const display = document.getElementById("display");
 
 // 地図表示関数の定義部分
 function initMap() {
+  // ページのロードがTurboだったらreturn
+  document.addEventListener("turbo:load", function () {
+    console.log("ページがロードされました（turbo:load）");
+    return;
+  });
+
+  // initMapが実行されたことを表示
+  console.log("initMapが実行されました");
+
   geocoder = new google.maps.Geocoder();
   const mapElement = document.getElementById("map");
   if (!mapElement) {
     console.error("Map element not found.");
     return;
   }
+
+  // マーカー初期化
+  clearMarkers();
 
   // ピンに使用するアイコンの設定
   const icons = {
@@ -26,6 +38,29 @@ function initMap() {
     },
   };
 
+  // mapの定義と基本設定（現在地取得できなかったとき）
+  map = new google.maps.Map(document.getElementById("map"), {
+    center: { lat: defaultLocation.lat, lng: defaultLocation.lng }, //東京駅
+    zoom: 15,
+    streetViewControl: false, // ストリートビューのボタン非表示
+    mapTypeControl: false, // 地図、航空写真のボタン非表示
+    fullscreenControl: false, // フルスクリーンボタン非表示
+  });
+
+  // lastCenter = map.getCenter();
+
+  // マップのドラッグ終了イベント
+  // map.addListener("dragend", function () {
+  //   centerPin.setPosition(map.getCenter());
+  //   lastCenter = map.getCenter();
+  // });
+
+  // infoWindowを作成
+  infoWindow = new google.maps.InfoWindow({
+    pixelOffset: new google.maps.Size(0, -50),
+    maxWidth: 300,
+  });
+
   // 地図の取得を開始する前にローディングを表示
   const loadingElement = document.getElementById("loading");
   mapElement.classList.add("loading");
@@ -35,160 +70,128 @@ function initMap() {
   const inputSearchWords = document.getElementById("name_or_address").value;
 
   if (inputSearchWords) {
+    //分岐の確認（ワード検索）
+    console.log("ワード検索");
+
     //検索ワードがある場合
-    const searchBagelShops = gon.search_bagel_shops;
-    let bounds = new google.maps.LatLngBounds(); // 検索結果が1つ以上の場合に地図の範囲を調整するためのBoundsオブジェクトを作成
-    // searchAddress();
+    searchBagelShops = gon.search_bagel_shops || [];
+    bounds = new google.maps.LatLngBounds(); // 検索結果が1つ以上の場合に地図の範囲を調整するためのBoundsオブジェクトを作成
 
-    // 地図基本設定（現在地取得できなかったとき）
-    map = new google.maps.Map(document.getElementById("map"), {
-      center: { lat: defaultLocation.lat, lng: defaultLocation.lng }, //東京駅
-      zoom: 15,
-      streetViewControl: false, // ストリートビューのボタン非表示
-      mapTypeControl: false, // 地図、航空写真のボタン非表示
-      fullscreenControl: false, // フルスクリーンボタン非表示
-    });
-
-    // センターピンの表示
-    // centerPin = new google.maps.Marker({
-    //   map: map,
-    //   draggable: true,
-    //   position: map.getCenter(), // 初期位置をマップの中心に設定
-    //   title: "現在地",
-    // });
-
-    lastCenter = map.getCenter();
-
-    // マップのドラッグ終了イベント
-    map.addListener("dragend", function () {
-      // centerPin.setPosition(map.getCenter());
-      lastCenter = map.getCenter();
-    });
-
-    // infoWindowを作成
-    infoWindow = new google.maps.InfoWindow({
-      pixelOffset: new google.maps.Size(0, -50),
-      maxWidth: 300,
-    });
+    console.log("boundsの内容確認：", bounds);
+    console.log("検索結果の店舗データ:", searchBagelShops);
 
     // Railsから保存された店舗情報を取得して地図上にマーカーを表示
     searchBagelShops.forEach(function (shop) {
-      let markerLatLng = { lat: shop.latitude, lng: shop.longitude }; // 緯度経度のデータ作成
-      let operatingHours = "";
-      let icon = icons["closed_shop"]; // デフォルトでは「閉店中」のアイコン
-      let storeStatus = "準備中または不定期";
+      if (shop.latitude && shop.longitude) {
+        // 緯度経度があるかチェック
+        let markerLatLng = new google.maps.LatLng(
+          parseFloat(shop.latitude),
+          parseFloat(shop.longitude)
+        ); // 緯度経度のデータ作成
+        let operatingHours = ""; // 営業時間のデータ
+        let icon = icons["closed_shop"]; // デフォルトでは「閉店中」のアイコン
+        let storeStatus = "準備中または不定期"; // 店舗の営業状況、デフォルトでは「準備中または不定期」
 
-      // boundsに検索結果の緯度経度をプッシュ
-      bounds.extend(markerLatLng);
+        // boundsに検索結果の緯度経度をプッシュ
+        // console.log(markerLatLng)
+        bounds.extend(markerLatLng);
 
-      if (shop.opening_hours) {
-        // 営業時間情報があれば営業時間をパース
-        operatingHours = parseOperatingHours(shop.opening_hours);
+        if (shop.opening_hours) {
+          // 営業時間情報があれば営業時間をパース
+          operatingHours = parseOperatingHours(shop.opening_hours);
 
-        // 営業時間がパースできたら、営業中かどうかを判断
-        if (isOpen(operatingHours)) {
-          icon = icons["opening_shop"]; // 営業中の場合は「営業中」のアイコン
-          storeStatus = "営業中";
+          // 営業時間がパースできたら、営業中かどうかを判断
+          if (isOpen(operatingHours)) {
+            icon = icons["opening_shop"]; // 営業中の場合は「営業中」のアイコン
+            storeStatus = "営業中";
+          }
         }
+
+        const marker = new google.maps.Marker({
+          position: markerLatLng,
+          map: map,
+          icon: icon,
+        });
+        markers.push(marker);
+
+        // マーカーがクリックされたときに情報ウィンドウを表示
+        marker.addListener("click", function () {
+          // photo_referenceをカンマで分割して最初の画像を使用
+          if (shop.photo_references) {
+            // 画像がある場合
+            const photoReferences = shop.photo_references.split(",");
+            const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReferences[0]}&key=${apiKey}`;
+
+            // infoWindowの内容を更新
+            infoWindow.setContent(`
+              <div class="custom-info">
+              <div class="custom-info-item store_status">${storeStatus}</div>
+              <div class="custom-info-item photo">
+              <img src="${photoUrl}" alt="${
+              shop.name
+            }" style="width:100%;height:auto;">
+              </div>
+              <div class="custom-info-item name">${shop.name}</div>
+              <div class="custom-info-item address">${shop.address}</div>
+              <div class="custom-info-item rating">⭐${
+                shop.rating ? shop.rating : "評価なし"
+              }</div>
+              <div class="custom-info-item link_to_detail">
+              <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
+              </div>
+              </div>
+            `);
+          } else {
+            // 画像がない場合
+            // infoWindowの内容を更新
+            infoWindow.setContent(`
+              <div class="custom-info">
+              <div class="custom-info-item store_status">${storeStatus}</div>
+              <div class="custom-info-item name">${shop.name}</div>
+              <div class="custom-info-item address">${shop.address}</div>
+              <div class="custom-info-item rating">⭐${
+                shop.rating ? shop.rating : "評価なし"
+              }</div>
+              <div class="custom-info-item link_to_detail">
+              <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
+              </div>
+              </div>
+            `);
+          }
+
+          // infoWindowを指定したマーカーの位置に表示
+          infoWindow.open(map, marker);
+        });
+      } else {
+        console.warn(`Invalid coordinates for shop: ${shop.name}`, shop);
       }
-
-      let marker = new google.maps.Marker({
-        position: markerLatLng,
-        map: map,
-        icon: icon,
-      });
-
-      // マーカーがクリックされたときに情報ウィンドウを表示
-      marker.addListener("click", function () {
-        // photo_referenceをカンマで分割して最初の画像を使用
-        if (shop.photo_references) {
-          // 画像がある場合
-          const photoReferences = shop.photo_references.split(",");
-          const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReferences[0]}&key=${apiKey}`;
-
-          // infoWindowの内容を更新
-          infoWindow.setContent(`
-            <div class="custom-info">
-            <div class="custom-info-item store_status">${storeStatus}</div>
-            <div class="custom-info-item photo">
-            <img src="${photoUrl}" alt="${
-            shop.name
-          }" style="width:100%;height:auto;">
-            </div>
-            <div class="custom-info-item name">${shop.name}</div>
-            <div class="custom-info-item address">${shop.address}</div>
-            <div class="custom-info-item rating">⭐${
-              shop.rating ? shop.rating : "評価なし"
-            }</div>
-            <div class="custom-info-item link_to_detail">
-            <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
-            </div>
-            </div>
-          `);
-        } else {
-          // 画像がない場合
-          // infoWindowの内容を更新
-          infoWindow.setContent(`
-            <div class="custom-info">
-            <div class="custom-info-item store_status">${storeStatus}</div>
-            <div class="custom-info-item name">${shop.name}</div>
-            <div class="custom-info-item address">${shop.address}</div>
-            <div class="custom-info-item rating">⭐${
-              shop.rating ? shop.rating : "評価なし"
-            }</div>
-            <div class="custom-info-item link_to_detail">
-            <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
-            </div>
-            </div>
-          `);
-        }
-
-        // infoWindowを指定したマーカーの位置に表示
-        infoWindow.open(map, marker);
-      });
     });
 
+    // `bounds` のデバッグ用ログ
+    console.log("Bounds object:", bounds);
+    console.log(
+      "Bounds instanceof LatLngBounds:",
+      bounds instanceof google.maps.LatLngBounds
+    );
+
     // 引数に指定した矩形領域を地図に収める
-    map.fitBounds(bounds);
+    google.maps.event.addListenerOnce(map, "idle", function () {
+      if (!bounds.isEmpty()) {
+        map.fitBounds(bounds);
+      } else {
+        console.warn("No valid locations to fitBounds.");
+      }
+    });
 
     // 位置情報が取得できたらローディングを非表示
     document.getElementById("loading").style.display = "none";
     document.getElementById("map").classList.remove("loading");
+  } else {
+    //検索ワードがない場合（現在地取得の場合）
+    console.log("現在地取得");
 
-  } else { //検索ワードがない場合（現在地取得の場合）
-    const bagelShops = gon.bagel_shops;
+    bagelShops = gon.bagel_shops;
     showCurrentLocation();
-
-    // 地図基本設定（現在地取得できなかったとき）
-    map = new google.maps.Map(document.getElementById("map"), {
-      center: { lat: defaultLocation.lat, lng: defaultLocation.lng }, //東京駅
-      zoom: 15,
-      streetViewControl: false, // ストリートビューのボタン非表示
-      mapTypeControl: false, // 地図、航空写真のボタン非表示
-      fullscreenControl: false, // フルスクリーンボタン非表示
-    });
-
-    // センターピンの表示
-    centerPin = new google.maps.Marker({
-    map: map,
-    draggable: true,
-    position: map.getCenter(), // 初期位置をマップの中心に設定
-    title: "現在地",
-    });
-
-    lastCenter = map.getCenter();
-
-    // マップのドラッグ終了イベント
-    // map.addListener("dragend", function () {
-    //   centerPin.setPosition(map.getCenter());
-    //   lastCenter = map.getCenter();
-    // });
-
-    // infoWindowを作成
-    infoWindow = new google.maps.InfoWindow({
-      pixelOffset: new google.maps.Size(0, -50),
-      maxWidth: 300,
-    });
 
     // Railsから保存された店舗情報を取得して地図上にマーカーを表示
     bagelShops.forEach(function (shop) {
@@ -208,11 +211,12 @@ function initMap() {
         }
       }
 
-      let marker = new google.maps.Marker({
+      const marker = new google.maps.Marker({
         position: markerLatLng,
         map: map,
         icon: icon,
       });
+      markers.push(marker);
 
       // マーカーがクリックされたときに情報ウィンドウを表示
       marker.addListener("click", function () {
@@ -228,14 +232,14 @@ function initMap() {
             <div class="custom-info-item store_status">${storeStatus}</div>
             <div class="custom-info-item photo">
             <img src="${photoUrl}" alt="${
-              shop.name
-              }" style="width:100%;height:auto;">
+            shop.name
+          }" style="width:100%;height:auto;">
               </div>
               <div class="custom-info-item name">${shop.name}</div>
               <div class="custom-info-item address">${shop.address}</div>
               <div class="custom-info-item rating">⭐${
                 shop.rating ? shop.rating : "評価なし"
-                }</div>
+              }</div>
                 <div class="custom-info-item link_to_detail">
                 <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
                 </div>
@@ -251,7 +255,7 @@ function initMap() {
             <div class="custom-info-item address">${shop.address}</div>
             <div class="custom-info-item rating">⭐${
               shop.rating ? shop.rating : "評価なし"
-              }</div>
+            }</div>
               <div class="custom-info-item link_to_detail">
               <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
               </div>
@@ -260,10 +264,10 @@ function initMap() {
         }
 
         // infoWindowを指定したマーカーの位置に表示
-        infoWindow.open(map, marker);
+        infoWindow.open(map, markers);
       });
     });
-  };
+  }
 
   // 地図上のボタンを押すとshowCurrentLocation関数で現在地を取得して表示
   const locationButton = document.createElement("button");
@@ -273,13 +277,13 @@ function initMap() {
   locationButton.addEventListener("click", showCurrentLocation);
 }
 
-
 // 既存のマーカーをすべて消去する関数
 function clearMarkers() {
   for (let i = 0; i < markers.length; i++) {
     markers[i].setMap(null);
   }
   markers = []; // 配列をクリア
+  console.log("マーカー初期化")
 }
 
 // infoWindowのエラーメッセージを出力する関数
@@ -296,6 +300,15 @@ function handleLocationError(browserHasGeolocation, infoWindow, pos) {
 // 現在地を取得して表示する関数
 function showCurrentLocation(){
   // Try HTML5 geolocation.
+
+  // センターピンの表示
+  centerPin = new google.maps.Marker({
+      map: map,
+      draggable: true,
+      position: map.getCenter(), // 初期位置をマップの中心に設定
+      title: "現在地",
+  });
+
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -370,7 +383,17 @@ function isOpen(operatingHours, now = new Date()) {
 
 // 画面表示部分
 
-window.initMap = initMap;
+document.addEventListener("DOMContentLoaded", function () {
+  if (typeof google === "undefined" || typeof google.maps === "undefined") {
+    console.error("Google Maps API のロードに失敗しました。");
+    return;
+  }
+  // console.log("Google Maps API スクリプトが読み込まれたか確認:", typeof google !== "undefined");
+  // console.log("地図の div が存在するか:", document.getElementById("map") !== null);
+  // console.log("地図のサイズ:", document.getElementById("map")?.clientWidth, document.getElementById("map")?.clientHeight);
+  // console.log("map 変数の状態:", map);
+  initMap();
+});
 
 window.addEventListener("popstate", function (e) {
   window.location.reload();

--- a/app/views/bagel_shops/index.html.erb
+++ b/app/views/bagel_shops/index.html.erb
@@ -8,9 +8,6 @@
 
 <div id="loading" style="display: none;">
   <p id="loading-text" class="mb-0" style="color: #595959;">
-    <span>現</span>
-    <span>在</span>
-    <span>地</span>
     <span>読</span>
     <span>み</span>
     <span>込</span>

--- a/app/views/bagel_shops/index.html.erb
+++ b/app/views/bagel_shops/index.html.erb
@@ -18,12 +18,6 @@
   <div class="spinner m-4"></div> <!-- スピナーのスタイルを適用 -->
 </div>
 
-<%#
-<input id="address" type="textbox" value="GeekSalon">
-<input type="button" value="Encode" onclick="codeAddress()">
-<div id="display">何かが表示される、、、、！</div>
-%>
-
 <% content_for(:title, t('.title')) %>
 <div class="contaner m-3">
   <div id="map" style="height:600px; width:100%;"></div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center">
   <!-- 検索フォーム -->
   <div class="search-form-container">
-    <%= search_form_for @q, url: bagel_shops_path do |f| %>
+    <%= search_form_for @q, url: bagel_shops_path, method: :get, data: { turbo: false } do |f| %>
     <div class="input-group">
       <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
       <div class="input-group-append">


### PR DESCRIPTION
## 概要

gmap.js内で現在地取得とワード検索の条件分岐のコード修正
[デバッグ]
同じワードで再検索した際に前回検索の結果が表示される現象を修正

## 変更点

- app/controllers/application_controller.rb
  - set_searchメソッド
    - gonで引き渡す店舗データの初期化
    - gonで引き渡す記載位置の変更
- app/javascript/gmap.js
  - Turbo時にreturn
  - initMaps実行時にMarkersの初期化
  - ドラッグ後のセンターピンを移動する処理をコメントアウト
  - searchAddress関数を削除し、initMaps内の条件分岐内に検索結果の地図表示を記載
  - 初期のcenterPinの設定をshowCurrentLocation関数内に移動
  - GoogleMapsAPIの取得が上手くいかないときに再取得せずreturn
- app/views/bagel_shops/index.html.erb
  - ロード画面の文字修正
  - コメントアウト部分（座標の出力）削除
- app/views/shared/_search_form.html.erb
  - 検索フォームの属性を追記
    - method: :get
    - data: {turbo: false}

## 影響範囲

indexページへの遷移が正常に動作する
一度検索したワードを再度検索したときに前回の検索結果が地図上に表示される現象を解消

## テスト

- localhostにて動作の確認
  1. トップページから現在地取得ボタンを押してindexページに遷移
  2. indexページからヘッダーの検索フォームで「池袋」と検索し、indexページをリロード
  3. indexページからヘッダーの検索フォームで「吉祥寺」と検索し、indexページをリロード
  4. indexページからヘッダーの検索フォームで「池袋」と検索し、indexページをリロード
  修正前は４の過程で「吉祥寺」の結果が地図に出力

## 関連Issue

- 関連Issue: #86 