### PR TITLE
update: 店舗検索で結果の店舗数が少ないときに地図がズームしすぎていたため、ズームの上限を設定

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -178,6 +178,12 @@ function initMap() {
     google.maps.event.addListenerOnce(map, "idle", function () {
       if (!bounds.isEmpty()) {
         map.fitBounds(bounds);
+
+        // ズームレベルの制限
+        const minZoomLevel = 17; // ズームレベル17以上にしない
+        if (map.getZoom() > minZoomLevel) {
+          map.setZoom(minZoomLevel);
+        }
       } else {
         console.warn("No valid locations to fitBounds.");
       }


### PR DESCRIPTION
## 概要

店舗検索で結果の店舗数が少ないときに地図がズームしすぎていたため、ズームの上限を設定

## 変更点

- modified:   app/javascript/gmap.js
  - firBoundsで地図に店舗ピンが収まるように収縮した後、地図のズームが17より大きかったらズームを17に変更

## 影響範囲

特になし

## テスト

- localhostで検索結果の少ないときの縮尺が一定に調整されていることを確認
- localhostで検索結果のある程度存在し縮尺の調整が必要ない時に今まで通りに表示されることを確認

## 関連Issue

- 関連Issue: #91 