### PR TITLE
add: 検索後のindexページで表示されている店舗情報を元に戻すリセットボタンを作成

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -132,3 +132,16 @@ body {
 .sort-links-container a:hover {
   text-decoration: underline;
 }
+
+.btn-reset {
+  background-color: #FFFFFF; /* ページネーションのアクティブ色 */
+  color: #A9907E; /* テキストカラー */
+  padding: 0.5rem; /* パディングを設定 */
+  border-radius: 0.25rem; /* 角を丸くする */
+  font-size: 1rem; /* フォントサイズを設定 */
+}
+
+.btn-reset:hover {
+  background-color: #8F7C68; /* 少し暗いトーンに */
+  color: #FFFFFF; /* テキストは白のまま */
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
       gon.search_bagel_shops = @bagel_shops
     end
 
-    puts "gon.search_bagel_shops: #{@bagel_shops.inspect}"
+    # puts "gon.search_bagel_shops: #{@bagel_shops.inspect}"
 
     return unless params[:search_button]
 

--- a/app/controllers/bagel_shops_controller.rb
+++ b/app/controllers/bagel_shops_controller.rb
@@ -2,6 +2,14 @@ class BagelShopsController < ApplicationController
   def index
     # @q = BagelShop.ransack(params[:q])
     # @bagel_shops = @q.result(distinct: true).page(params[:page])
+
+    # `reset=true` が渡されたら全店舗情報を取得し直す
+    if params[:reset]
+      gon.reset_button_clicked = true # JS に「リセットが押された」ことを渡す
+    else
+      gon.reset_button_clicked = false
+    end
+
     gon.bagel_shops = BagelShop.all
     gon.api_key = ENV["GMAPS_API_KEY"]
   end

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,4 +1,5 @@
 let map, geocoder, centerPin, infoWindow, lastCenter, bagelShops, searchBagelShops, mode;
+let lastZoom;
 let markers = [];
 const apiKey = gon.api_key;
 
@@ -41,12 +42,16 @@ function initMap() {
     },
   };
 
+  console.log("zoom:", lastZoom);
+
   // mapの定義と基本設定（現在地取得できなかったとき）
   map = new google.maps.Map(document.getElementById("map"), {
     center: lastCenter
       ? { lat: lastCenter.lat(), lng: lastCenter.lng() }
       : { lat: defaultLocation.lat, lng: defaultLocation.lng }, // lastCenterがあれば使用
-    zoom: 15,
+    zoom: lastZoom
+      ? lastZoom
+      : 15, // lastCenterがあれば使用
     streetViewControl: false, // ストリートビューのボタン非表示
     mapTypeControl: false, // 地図、航空写真のボタン非表示
     fullscreenControl: false, // フルスクリーンボタン非表示
@@ -55,12 +60,9 @@ function initMap() {
   // マップのドラッグ終了イベント
   map.addListener("dragend", function () {
     lastCenter = map.getCenter();
+    lastZoom = map.getZoom();
     console.log("ドラッグ後座標：", lastCenter.lat(), lastCenter.lng());
   });
-
-  if (lastCenter) {
-    console.log("ドラッグ後座標：", lastCenter.lat(), lastCenter.lng());
-  }
 
   // infoWindowを作成
   infoWindow = new google.maps.InfoWindow({
@@ -291,6 +293,8 @@ function initMap() {
           const minZoomLevel = 17; // ズームレベル17以上にしない
           if (map.getZoom() > minZoomLevel) {
             map.setZoom(minZoomLevel);
+            lastZoom = map.getZoom();
+            console.log("zoom:", lastZoom);
           }
         } else {
           console.warn("No valid locations to fitBounds.");
@@ -449,8 +453,11 @@ function showCurrentLocation(){
           centerPin.setPosition(pos);
         }
 
+        // 現在地の座標を記録
         lastCenter = map.getCenter();
+        lastZoom = map.getZoom();
         console.log("現在地取得後座標：", lastCenter.lat(), lastCenter.lng());
+        console.log("zoom:", lastZoom);
 
         // 位置情報が取得できたらローディングを非表示
         document.getElementById("loading").style.display = "none";

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,9 +6,19 @@
     <%= image_tag 'logo.png' %>
     <% end %>
 
-    <!-- 検索フォーム -->
-    <div class="container">
-      <%= render 'shared/search_form', url: bagel_shops_path, q: @q %>
+    <!-- 検索フォーム & リセットボタンを横並び -->
+    <div class="container d-flex flex-row align-items-center justify-content-start">
+      <!-- 検索フォーム -->
+      <div class="w-auto">
+        <%= render 'shared/search_form', url: bagel_shops_path, q: @q %>
+      </div>
+
+      <!-- リセットボタン -->
+      <div>
+        <%= link_to bagel_shops_path, class: 'btn btn-reset btn-lg p-2 ms-2' do %>
+        <i class=" fa-solid fa-rotate-right"></i> リセット
+        <% end %>
+      </div>
     </div>
 
     <%

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
 
       <!-- リセットボタン -->
       <div>
-        <%= link_to bagel_shops_path, class: 'btn btn-reset btn-lg p-2 ms-2' do %>
+        <%= link_to bagel_shops_path(reset: true), class: 'btn btn-reset btn-lg p-2 ms-2' do %>
         <i class=" fa-solid fa-rotate-right"></i> リセット
         <% end %>
       </div>


### PR DESCRIPTION
## 概要

検索後のindexページで表示されている店舗情報を元に戻すリセットボタンを作成

## 変更点

- modified:   app/assets/stylesheets/application.bootstrap.scss
  - リセットボタンのスタイル追記
    - btn-reset
    - btn-reset:hover
- modified:   app/controllers/application_controller.rb
- modified:   app/controllers/bagel_shops_controller.rb
  - リセットボタンを押してindexアクションをリロードしたときに"reset"の有無による条件分岐を追記
    - reset == true
      gonでJSにtrueを渡す
    - reset == false
      gonでJSにfalseを渡す
- modified:   app/javascript/gmap.js
  - if文の条件分岐をswitch文に変更
    - 検索ワードなしかつリセットではないとき
      ケース：currentLocation
    - 検索ワードありかつリセットではないとき
      ケース：wordSearch
    - リセットのとき
      ケース：reset
  - lastCenterに地図の中心地を記録しページ更新後に適用
    - 現在地取得、店舗検索時に中心座標をgetCenterで取得しlastCenterに入力
    - ドラッグイベント時に中心座標をgetCenterで取得しlastCenterに入力
  - lastZoomに地図の縮尺を記録しページ更新後に適用
    - 現在地取得、店舗検索時に縮尺をgetZoomで取得しlastZoomに入力
    - ドラッグイベント時に縮尺をgetZoomで取得しlastZoomに入力
- modified:   app/views/shared/_header.html.erb
  - リセットボタンの設置

## 影響範囲

indexページの表示において挙動が変更される
挙動の詳細はテストに記載

## テスト

- localhostにてページ遷移の挙動を確認
  - トップページから現在地取得したときの遷移を確認
    1. トップページの現在地取得ボタンを押す
    2. indexページに遷移
    3. 現在地の中心の全店舗表示された地図を確認
    4. 全店舗の店舗リストが表示されたのを確認
  - 検索フォームから店舗検索したときの遷移を確認
    1. 検索フォームに入力し検索
    2. indexページをリロード
    3. 検索結果の店舗数に合わせて中心、縮尺の変更を確認
    4. 検索結果の店舗リストが表示されたのを確認
  - リセットしたときの遷移を確認
    1. リセットボタンを押す
    2. indexページをリロード
    3. 中心座標、縮尺を維持したまま店舗ピンを全店舗表示されたのを確認
    4. 店舗リストが全店舗にリセットされたのを確認
  - ドラッグ時の中心座標の変更を確認
    1. 地図をドラッグして中心座標が変更されたのをログで確認
    2. リセットボタンを押したときに中心座標が引き継がれているのを確認
  - 縮尺が引き継がれているのを確認
    1. 地図の縮尺を変更
    2. リセットボタンを押したときに縮尺が引き継がれているのを確認

## 関連Issue

- 関連Issue: #92 