### PR TITLE
fix: indexページでのみリセットボタンが表示されるように表示条件を設定

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -51,7 +51,7 @@ function initMap() {
       : { lat: defaultLocation.lat, lng: defaultLocation.lng }, // lastCenterがあれば使用
     zoom: lastZoom
       ? lastZoom
-      : 15, // lastCenterがあれば使用
+      : 15, // lastZoomがあれば使用
     streetViewControl: false, // ストリートビューのボタン非表示
     mapTypeControl: false, // 地図、航空写真のボタン非表示
     fullscreenControl: false, // フルスクリーンボタン非表示

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,11 +14,13 @@
       </div>
 
       <!-- リセットボタン -->
+      <% if current_page?(bagel_shops_path) %>
       <div>
         <%= link_to bagel_shops_path(reset: true), class: 'btn btn-reset btn-lg p-2 ms-2' do %>
         <i class=" fa-solid fa-rotate-right"></i> リセット
         <% end %>
       </div>
+      <% end %>
     </div>
 
     <%


### PR DESCRIPTION
## 概要

indexページ以外の地図がないページでもリセットボタンが表示されてしまうため、indexページでのみリセットボタンが表示されるように表示条件を設定

## 変更点

- modified:   app/javascript/gmap.js
- modified:   app/views/shared/_header.html.erb
  - current_page?でindexパスか判定

## 影響範囲

indexページ以外ではヘッダーにリセットボタンが表示されなくなる

## テスト

- localhostでindexページでのみリセットボタンが表示されるのを確認

## 関連Issue

- 関連Issue: #97 