### PR TITLE
add: ransackの検索機能にソート機能を実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -115,33 +115,94 @@ body {
   color: #595959 !important; /* カードの文字色 */
 }
 
+/* フォーム全体のスタイリング */
 .search-form-container {
   flex-grow: 1;
+  max-width: 400px;
 }
 
+.input-group {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.form-control {
+  border: 2px solid #A9907E;
+  border-right: none;
+  box-shadow: none;
+  height: 40px;
+}
+
+.form-control:focus {
+  border-color: #8F7C68;
+  // box-shadow: 0 0 5px rgba(143, 124, 104, 0.5);
+}
+
+.input-group-append .btn {
+  background-color: #EDE8E2;
+  border: 2px solid #A9907E;
+  color: #A9907E;
+  height: 40px;
+  // transition: all 0.3s;
+}
+
+.input-group-append .btn:hover {
+  background-color: #8F7C68;
+  color: #EDE8E2;
+  // border-color: #8F7C68;
+}
+
+/* ソートリンク */
 .sort-links-container {
   display: flex;
-  gap: 10px; /* ソートリンク間のスペース */
+  gap: 10px;
+  margin: 0 10px;
 }
 
 .sort-links-container a {
-  color: #007bff;
+  display: inline-block;
+  background-color: #EDE8E2;
+  color: #A9907E;
+  padding: 6px 12px;
+  border-radius: 5px;
   text-decoration: none;
+  font-size: 0.9rem;
+  // transition: background-color 0.3s;
 }
 
 .sort-links-container a:hover {
-  text-decoration: underline;
+  background-color: #8F7C68;
+  color: #EDE8E2;
+  text-decoration: none;
 }
 
+/* ボタンの統一デザイン */
 .btn-reset {
-  background-color: #FFFFFF; /* ページネーションのアクティブ色 */
-  color: #A9907E; /* テキストカラー */
-  padding: 0.5rem; /* パディングを設定 */
-  border-radius: 0.25rem; /* 角を丸くする */
-  font-size: 1rem; /* フォントサイズを設定 */
+  display: inline-block;
+  background-color: #EDE8E2;
+  color: #A9907E;
+  padding: 6px 12px;
+  border-radius: 5px;
+  font-size: 0.9rem;
+  // transition: all 0.3s;
+  // border: 2px solid #A9907E;
+  text-decoration: none;
 }
 
 .btn-reset:hover {
-  background-color: #8F7C68; /* 少し暗いトーンに */
-  color: #FFFFFF; /* テキストは白のまま */
+  background-color: #8F7C68;
+  color: #EDE8E2;
+  // border-color: #8F7C68;
+}
+
+/* レスポンシブ調整 */
+@media (max-width: 768px) {
+  .search-form-container {
+    max-width: 100%;
+  }
+
+  .sort-links-container {
+    flex-direction: column;
+    gap: 5px;
+  }
 }

--- a/app/models/bagel_shop.rb
+++ b/app/models/bagel_shop.rb
@@ -2,7 +2,7 @@ class BagelShop < ApplicationRecord
   validates :name, :latitude, :longitude, :place_id, presence: true, uniqueness: true
 
   def self.ransackable_attributes(auth_object = nil)
-    ["address", "name", "rating"]
+    ["address", "name", "rating", "user_ratings_total"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,21 +6,21 @@
     <%= image_tag 'logo.png' %>
     <% end %>
 
-    <!-- 検索フォーム & リセットボタンを横並び -->
-    <div class="container d-flex flex-row align-items-center justify-content-start">
+    <!-- 検索フォーム & リセットボタン -->
+    <div class="container d-flex align-items-center">
       <!-- 検索フォーム -->
-      <div class="w-auto">
+      <div class="flex-grow-1">
         <%= render 'shared/search_form', url: bagel_shops_path, q: @q %>
-      </div>
 
-      <!-- リセットボタン -->
-      <% if current_page?(bagel_shops_path) %>
-      <div>
-        <%= link_to bagel_shops_path(reset: true), class: 'btn btn-reset btn-lg p-2 ms-2' do %>
-        <i class=" fa-solid fa-rotate-right"></i> リセット
+        <!-- リセットボタン -->
+        <% if current_page?(bagel_shops_path) %>
+        <div class="ms-auto">
+          <%= link_to bagel_shops_path(reset: true), class: 'btn-reset' do %>
+          <i class="fa-solid fa-rotate-right"></i> 店舗リセット
+          <% end %>
+        </div>
         <% end %>
       </div>
-      <% end %>
     </div>
 
     <%

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -6,7 +6,7 @@
       <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
       <div class="input-group-append">
         <%= button_tag type: 'submit', class: 'btn btn-primary', name: 'search_button' do %>
-        <i class="fa-solid fa-magnifying-glass" style="color: #ede8e2;"></i>
+        <i class="fa-solid fa-magnifying-glass"></i>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -14,8 +14,10 @@
   </div>
 
   <!-- ソート -->
+  <% if current_page?(bagel_shops_path) %>
   <div class="sort-links-container">
     <%= sort_link(@q, :rating, '評価順', default_order: :desc) %>
     <%= sort_link(@q, :user_ratings_total, 'コメント数順', default_order: :desc) %>
     <!-- <%= sort_link(@q, :distance, '距離順') %> </div> -->
   </div>
+  <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -13,9 +13,9 @@
     <% end %>
   </div>
 
-  <!-- ソート
+  <!-- ソート -->
   <div class="sort-links-container">
-    <%= sort_link(@q, :rating, '評価順') %>
-    <%= sort_link(@q, :distance, '距離順') %>
-  </div> -->
-</div>
+    <%= sort_link(@q, :rating, '評価順', default_order: :desc) %>
+    <%= sort_link(@q, :user_ratings_total, 'コメント数順', default_order: :desc) %>
+    <!-- <%= sort_link(@q, :distance, '距離順') %> </div> -->
+  </div>


### PR DESCRIPTION
## 概要

ransackを使用してソートボタンを追加

## 変更点

- modified:   app/assets/stylesheets/application.bootstrap.scss
- modified:   app/models/bagel_shop.rb
  - ransack_attriburesにuser_ratings_totalを追加
- modified:   app/views/shared/_header.html.erb
  - 配置の調整
- modified:   app/views/shared/_search_form.html.erb
  - ソートの追記

## 影響範囲

indexページでの店舗一覧の挙動が追加される

## テスト

- localhostで確認
  - indexページでのみソートボタンが表示されるのを確認
  - ソートボタンを押したときに店舗一覧が並び替えられているのを確認

## 関連Issue

- 関連Issue: #100 