### PR TITLE
add: ransackの検索機能に絞り込み機能を実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -206,3 +206,39 @@ body {
     gap: 5px;
   }
 }
+
+/* 絞り込みボタン */
+.btn-filter {
+  background-color: #EDE8E2;
+  color: #A9907E;
+  padding: 6px 12px;
+  border-radius: 5px;
+  font-size: 0.9rem;
+  text-decoration: none;
+  // border: 2px solid #A9907E;
+}
+
+.btn-filter:hover {
+  background-color: #8F7C68;
+  color: #EDE8E2;
+}
+
+/* 絞り込みドロップダウン */
+.dropdown-menu {
+  background-color: #EDE8E2;
+  border: 2px solid #A9907E;
+  border-radius: 10px;
+  padding: 15px;
+  min-width: 320px;
+}
+
+/* 入力欄のデザイン統一 */
+.dropdown-menu .form-control {
+  border: 2px solid #A9907E;
+  background-color: #fff;
+}
+
+.dropdown-menu .form-control:focus {
+  border-color: #8F7C68;
+  box-shadow: 0 0 5px rgba(143, 124, 104, 0.5);
+}

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center">
   <!-- 検索フォーム -->
-  <div class="search-form-container">
-    <%= search_form_for @q, url: bagel_shops_path, method: :get, data: { turbo: false } do |f| %>
+  <%= search_form_for @q, url: bagel_shops_path, method: :get, data: { turbo: false } do |f| %>
+  <div class="search-form-container d-flex align-items-center">
     <div class="input-group">
       <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
       <div class="input-group-append">
@@ -11,14 +11,28 @@
       </div>
     </div>
 
-    <div class="input-group mb-3">
-      <%= f.label :rating_gteq, "評価が以上" %>
-      <%= f.number_field :rating_gteq, class: "form-control", step: "0.1", placeholder: "例: 4.0" %>
-    </div>
+    <!-- 絞り込みボタン（ドロップダウン） -->
+    <div class="dropdown ms-2">
+      <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
+        <i class="fa-solid fa-filter"></i> 絞り込み
+      </button>
 
-    <div class="input-group mb-3">
-      <%= f.label :user_ratings_total_gteq, "コメント数が以上" %>
-      <%= f.number_field :user_ratings_total_gteq, class: "form-control", placeholder: "例: 50" %>
+      <!-- 絞り込みフォーム（ドロップダウンの中） -->
+      <div class="dropdown-menu p-4" style="min-width: 250px;">
+        <div class="mb-3">
+          <%= f.label :rating_gteq, "評価" %>
+          <div class="input-group">
+            <%= f.number_field :rating_gteq, class: "form-control", step: "0.1", placeholder: "例: 4.0" %>
+            <span class="input-group-text">以上</span>
+          </div>
+        </div>
+
+        <%= f.label :user_ratings_total_gteq, "コメント数" %>
+        <div class="input-group">
+          <%= f.number_field :user_ratings_total_gteq, class: "form-control", placeholder: "例: 50" %>
+          <span class="input-group-text">以上</span>
+        </div>
+      </div>
     </div>
     <% end %>
   </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -13,7 +13,7 @@
 
     <!-- 絞り込みボタン（ドロップダウン） -->
     <div class="dropdown ms-2">
-      <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
+      <button class="btn btn-filter dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
         <i class="fa-solid fa-filter"></i> 絞り込み
       </button>
 

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -10,6 +10,16 @@
         <% end %>
       </div>
     </div>
+
+    <div class="input-group mb-3">
+      <%= f.label :rating_gteq, "評価が以上" %>
+      <%= f.number_field :rating_gteq, class: "form-control", step: "0.1", placeholder: "例: 4.0" %>
+    </div>
+
+    <div class="input-group mb-3">
+      <%= f.label :user_ratings_total_gteq, "コメント数が以上" %>
+      <%= f.number_field :user_ratings_total_gteq, class: "form-control", placeholder: "例: 50" %>
+    </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
## 概要

ransackを使用して絞り込みボタンを追加し、評価とコメント数で絞り込みする機能を実装

## 変更点

- modified:   app/assets/stylesheets/application.bootstrap.scss
- modified:   app/views/shared/_search_form.html.erb
  - 絞り込み（ドロップダウン）の追記

## 影響範囲

indexページでの店舗一覧の挙動が追加される

## テスト

- localhostで確認
  - 絞り込みボタンが常時ヘッダーに表示されるのを確認
  - 絞り込みボタンを押したときにドロップダウンが展開し、下記項目の入力フォームが表示されるのを確認
    - 評価
    - コメント数
  - 各項目で絞り込み検索を行い、結果が地図上のピン、一覧表示ともに反映されるのを確認
  - 両項目で絞り込み検索を行い、結果が地図上のピン、一覧表示ともに反映されるのを確認

## 関連Issue

- 関連Issue: #34 