### PR TITLE
add: showページにルート検索ボタンを実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -9,6 +9,7 @@
 @import 'bootstrap-icons/font/bootstrap-icons';
 @import 'top';
 @import 'map';
+@import 'show';
 
 .pagination {
   justify-content: center;

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,0 +1,51 @@
+/* 店舗画像 */
+.shop-image {
+  object-fit: cover;
+  width: 100%;
+  height: 400px;
+}
+
+/* 店舗地図 */
+.shop-map {
+  height: 400px;
+  width: 100%;
+}
+
+/* 店舗詳細部分のスタイル */
+.shop-info-section {
+  padding-top: 15px;
+  border-top: 3px solid #A9907E;
+}
+
+/* スライドバー */
+.sticky-sidebar {
+  position: sticky;
+  top: 3rem; // 上部の余白
+  max-height: 80vh; // 画面の80%の高さまで表示
+  overflow-y: auto; // 必要ならスクロール可能に
+}
+
+/* ルートリンクボタン */
+.btn-route {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px; // アイコンとテキストの間隔
+  width: 200px; // ボタンの幅を調整
+  padding: 8px 12px; // 内側の余白を調整
+  font-size: 16px; // 文字サイズを適切に
+  border-radius: 20px; // 角を丸くする
+  background-color: #A9907E; // ボタンの背景色
+  color: white; // 文字色
+  text-decoration: none; // 下線を消す
+  border: none; // 枠線なし
+  // transition: background-color 0.3s ease;
+}
+
+.btn-route:hover {
+  background-color: #8F7C68; // ホバー時の色
+}
+
+.btn-route i {
+  font-size: 20px; // アイコンのサイズを大きくする
+}

--- a/app/views/bagel_shops/show.html.erb
+++ b/app/views/bagel_shops/show.html.erb
@@ -9,9 +9,9 @@
 
       <div class="card mb-4">
         <% if @bagel_shop.photo_references.present? %>
-        <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=#{@bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: @bagel_shop.name, size: "400x400", class: "card-img-top", style: "object-fit: cover;" %>
+        <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=#{@bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: @bagel_shop.name, size: "400x400", class: "card-img-top shop-image", style: "object-fit: cover;" %>
         <% else %>
-        <%= image_tag "bagel_shop_placeholder.jpg", class: "card-img-top", width: "400", height: "400", style: "object-fit: cover;" %>
+        <%= image_tag "bagel_shop_placeholder.jpg", class: "card-img-top shop-image", width: "400", height: "400", style: "object-fit: cover;" %>
         <% end %>
       </div>
 
@@ -22,7 +22,7 @@
       <p>評価がありません</p>
       <% end %>
 
-      <div class="mb-3 pt-3 border-top border-3 custom-border-color">
+      <div class="mb-3 shop-info-section">
         <strong>営業時間</strong>
         <% if @opening_hours.present? %>
         <% @opening_hours.each do |opening_hour| %>
@@ -33,7 +33,7 @@
         <% end %>
       </div>
 
-      <div class="mb-3 pt-3 border-top border-3 custom-border-color">
+      <div class="mb-3 shop-info-section">
         <strong>電話番号</strong>
         <% if @bagel_shop.formatted_phone_number.present? %>
         <p><%= @bagel_shop.formatted_phone_number %></p>
@@ -42,7 +42,7 @@
         <% end %>
       </div>
 
-      <div class="mb-3 pt-3 border-top border-3 custom-border-color">
+      <div class="mb-3 shop-info-section">
         <strong>公式サイト・SNS</strong>
         <% if @bagel_shop.website.present? %>
         <p><%= link_to @bagel_shop.website, @bagel_shop.website, target: :_blank, rel: "noopener noreferrer"%></p>
@@ -51,24 +51,26 @@
         <% end %>
       </div>
 
-      <div class="mb-3 pt-3 border-top border-3 custom-border-color">
+      <div class="mb-3 shop-info-section">
         <strong>住所</strong>
         <p><%= @bagel_shop.address %></p>
       </div>
 
-      <div class="mb-4 pt-3 border-top border-3 custom-border-color">
-        <div id="map" style="height:400px; width:100%;"></div>
+      <div class="mb-4 shop-info-section">
+        <div id="map" class="shop-map"></div>
       </div>
     </div>
 
-    <div class="col-lg-3">
+    <div class="col-lg-3 mt-5 sticky-sidebar">
       <div class="list-group mb-4">
         <!--
           <%= link_to 'コメント投稿', '#', class: 'list-group-item list-group-item-action' %>
           <%= link_to 'お気に入り追加', '#', class: 'list-group-item list-group-item-action' %>
           <%= link_to 'お気に入り削除', '#', class: 'list-group-item list-group-item-action text-danger' %>
           -->
-        <%= link_to 'ルート検索', "https://www.google.com/maps/dir/?api=1&destination=#{@bagel_shop.latitude}-#{@bagel_shop.longitude}&destination_place_id=#{@bagel_shop.place_id}", class: 'list-group-item list-group-item-action' %>
+        <%= link_to "https://www.google.com/maps/dir/?api=1&destination=#{@bagel_shop.latitude}-#{@bagel_shop.longitude}&destination_place_id=#{@bagel_shop.place_id}", class: 'btn btn-route', target: :_blank, rel: "noopener noreferrer" do %>
+        <i class="fa-solid fa-route"></i>ルート
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/bagel_shops/show.html.erb
+++ b/app/views/bagel_shops/show.html.erb
@@ -4,7 +4,7 @@
 <% content_for(:title, @bagel_shop.name) %>
 <div class="container mt-4">
   <div class="row">
-    <div class="col-lg-8 offset-lg-2">
+    <div class="col-lg-7 offset-lg-2">
       <h2 class="mb-4"><%= t('.title') %></h2>
 
       <div class="card mb-4">
@@ -61,17 +61,15 @@
       </div>
     </div>
 
-    <%
-=begin%>
-    <div class="col-lg-4">
+    <div class="col-lg-3">
       <div class="list-group mb-4">
-        <%= link_to 'コメント投稿', '#', class: 'list-group-item list-group-item-action' %>
-        <%= link_to 'お気に入り追加', '#', class: 'list-group-item list-group-item-action' %>
-        <%= link_to 'お気に入り削除', '#', class: 'list-group-item list-group-item-action text-danger' %>
-        <%= link_to 'ルート検索', '#', class: 'list-group-item list-group-item-action' %>
+        <!--
+          <%= link_to 'コメント投稿', '#', class: 'list-group-item list-group-item-action' %>
+          <%= link_to 'お気に入り追加', '#', class: 'list-group-item list-group-item-action' %>
+          <%= link_to 'お気に入り削除', '#', class: 'list-group-item list-group-item-action text-danger' %>
+          -->
+        <%= link_to 'ルート検索', "https://www.google.com/maps/dir/?api=1&destination=#{@bagel_shop.latitude}-#{@bagel_shop.longitude}&destination_place_id=#{@bagel_shop.place_id}", class: 'list-group-item list-group-item-action' %>
       </div>
     </div>
-    <%
-=end%>
   </div>
 </div>


### PR DESCRIPTION
## 概要

showページの右側にルート検索ボタンを配置し、別タブでGoogleマップのルート検索結果が表示されるように実装

## 変更点

- modified:   app/assets/stylesheets/application.bootstrap.scss
  - show.scssのインポート
- new file:   app/assets/stylesheets/show.scss
  - showページのスタイル設定
- modified:   app/views/bagel_shops/show.html.erb
  - サイドバーの設置
  - Googleマップのルート検索ボタンの設置

## 影響範囲

showページでの店舗詳細の挙動が追加される

## テスト

- localhostで確認
  - showページにサイドバーとルート検索ボタンが表示されているのを確認
  - ルート検索ボタンを押すとGoogleマップのルート検索タブが開くのを確認
    - タブの検索結果
      出発地：現在地
      目的地：店舗所在地

## 関連Issue

- 関連Issue: #46 