### PR TITLE
fix: 店舗検索時のズームレベル17が以下のときにもズームレベルをlastZoomに保持するように変更

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -293,9 +293,11 @@ function initMap() {
           const minZoomLevel = 17; // ズームレベル17以上にしない
           if (map.getZoom() > minZoomLevel) {
             map.setZoom(minZoomLevel);
-            lastZoom = map.getZoom();
             console.log("zoom:", lastZoom);
           }
+
+          // ズームレベルをlastZoomに保持
+          lastZoom = map.getZoom();
         } else {
           console.warn("No valid locations to fitBounds.");
         }


### PR DESCRIPTION
## 概要

店舗検索時に複数店舗が結果として表示され、ズームレベル17以下となったとき、次にリセット操作をするとズームレベルがデフォルトに戻ってしまうため、lastZoomを常時保持するように変更

## 変更点

- modified:   app/javascript/gmap.js
  - 常時lastZoomにズームレベルを保持するように変更（ズームレベルの制限の条件分岐から出す）

## 影響範囲

店舗検索時に複数店舗が結果として表示され、ズームレベル17以下となったとき、次にリセット操作をしてもズームレベルが保持される

## テスト

- localhostで動作を確認
  - ズームレベルが低く（ズームレベル：17）なるように検索
  - リセットボタンを押す

## 関連Issue

- 関連Issue: #105 