### PR TITLE
fix: indexページの店舗ウィンドウが展開されるように変更

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -172,7 +172,7 @@ function initMap() {
           }
 
           // infoWindowを指定したマーカーの位置に表示
-          infoWindow.open(map, markers);
+          infoWindow.open(map, marker);
         });
       });
       break;
@@ -385,7 +385,7 @@ function initMap() {
           }
 
           // infoWindowを指定したマーカーの位置に表示
-          infoWindow.open(map, markers);
+          infoWindow.open(map, marker);
         });
       });
 


### PR DESCRIPTION
## 概要

indexページの地図上の店舗ピンをクリックしたときに、直前の遷移動作にかかわらずウィンドウが展開されるように変更

## 変更点

- modified:   app/javascript/gmap.js
  - 現在地取得、リセット動作条件
    修正前：infoWindow.open(map, markers)
    修正後：infoWindow.open(map, marker)

## 影響範囲

indexページの地図上の操作時に、直前の画面遷移動作にかかわらず店舗ウィンドウが展開される

## テスト

- localhostで確認
  - 現在地取得時の地図上の店舗ピンで展開できるのを確認
  - 店舗検索時の地図上の店舗ピンで展開できるのを確認
  - リセット時の地図上の店舗ピンで展開できるのを確認

## 関連Issue

- 関連Issue: #106 