### PR TITLE
fix: 検索フォームに未入力でも絞り込みできるように変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
     return unless params[:search_button]
 
-    if params[:q].present? && params[:q][:address_or_name_cont].blank?
+    if params[:q][:address_or_name_cont].blank? && params[:q][:rating_gteq].blank? && params[:q][:user_ratings_total_gteq].blank?
       flash[:warning] = '検索ワードが入力されていません'
       redirect_back(fallback_location: root_path)
     elsif @bagel_shops.empty?


### PR DESCRIPTION
## 概要

検索フォームが未入力のときにも絞り込み検索ができるように修正

## 変更点

- modified:   app/controllers/application_controller.rb
  - 検索フォーム未入力時の条件分岐に絞り込み検索フォームの条件を追記

## 影響範囲

全ページからの検索時のフラッシュメッセージ出力条件が変更

## テスト

- localhostで動作を確認
  - 検索フォーム：空欄　絞り込みフォーム：空欄
    リダイレクトバックしてフラッシュメッセージ表示
  - 検索フォーム：空欄　絞り込みフォーム：入力
    店舗一覧が絞り込み条件に基づいて表示
  - 検索フォーム：入力　絞り込みフォーム：空欄
    店舗一覧が検索結果に基づき表示
  - 検索フォーム：入力　絞り込みフォーム：入力
    店舗一覧が検索結果と絞り込み条件に基づき表示

## 関連Issue

- 関連Issue: #107