### PR TITLE
update: 画面スクロールでヘッダーが見えなくなってしまい再検索等がやりづらくなるため、ヘッダーを固定し常時表示するように変更

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -20,8 +20,8 @@
 /* スライドバー */
 .sticky-sidebar {
   position: sticky;
-  top: 3rem; // 上部の余白
-  max-height: 80vh; // 画面の80%の高さまで表示
+  top: 8rem; // 上部の余白
+  height: calc(100vh - 8rem); // 画面の高さからヘッダー分を引いた値を適用
   overflow-y: auto; // 必要ならスクロール可能に
 }
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header class="sticky-top">
   <nav class='navbar navbar-expand-lg navigation' style='background-color: #A9907E'>
 
     <!-- WEBアプリロゴ -->


### PR DESCRIPTION
## 概要

画面スクロールでヘッダーが見えなくなってしまい再検索等がやりづらくなるため、ヘッダーを固定し常時表示するように変更

## 変更点

- modified:   app/assets/stylesheets/show.scss
  - サイドバーの固定を調整
- modified:   app/views/shared/_header.html.erb
  - ヘッダーの固定を追記

## 影響範囲

全てのページでヘッダーが固定され、showページではサイドバーとヘッダーが干渉せずに常時表示される

## テスト

- localhostで動作を確認
  - ヘッダーが全ページで固定される
  - showページでヘッダーとサイドバーが干渉せずに固定される

## 関連Issue

- 関連Issue: #109 