### PR TITLE
fix: トップページの現在地取得から遷移したとき地図のズームレベルが固定値に統一されるように変更

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -42,34 +42,6 @@ function initMap() {
     },
   };
 
-  console.log("zoom:", lastZoom);
-
-  // mapの定義と基本設定（現在地取得できなかったとき）
-  map = new google.maps.Map(document.getElementById("map"), {
-    center: lastCenter
-      ? { lat: lastCenter.lat(), lng: lastCenter.lng() }
-      : { lat: defaultLocation.lat, lng: defaultLocation.lng }, // lastCenterがあれば使用
-    zoom: lastZoom
-      ? lastZoom
-      : 15, // lastZoomがあれば使用
-    streetViewControl: false, // ストリートビューのボタン非表示
-    mapTypeControl: false, // 地図、航空写真のボタン非表示
-    fullscreenControl: false, // フルスクリーンボタン非表示
-  });
-
-  // マップのドラッグ終了イベント
-  map.addListener("dragend", function () {
-    lastCenter = map.getCenter();
-    lastZoom = map.getZoom();
-    console.log("ドラッグ後座標：", lastCenter.lat(), lastCenter.lng());
-  });
-
-  // infoWindowを作成
-  infoWindow = new google.maps.InfoWindow({
-    pixelOffset: new google.maps.Size(0, -50),
-    maxWidth: 300,
-  });
-
   // 地図の取得を開始する前にローディングを表示
   const loadingElement = document.getElementById("loading");
   mapElement.classList.add("loading");
@@ -92,6 +64,36 @@ function initMap() {
     mode = "reset"; // ③リセットtrue
     console.log("mode：", mode);
   }
+
+  console.log("zoom:", lastZoom);
+
+  // mapの定義と基本設定（現在地取得できなかったとき）
+  map = new google.maps.Map(document.getElementById("map"), {
+    center: lastCenter
+      ? { lat: lastCenter.lat(), lng: lastCenter.lng() }
+      : { lat: defaultLocation.lat, lng: defaultLocation.lng }, // lastCenterがあれば使用
+    zoom: mode === "currentLocation"
+      ? 15
+      : lastZoom
+        ? lastZoom
+        : 15, // 現在地取得モードなら15、それ以外はlastZoomを使う
+    streetViewControl: false, // ストリートビューのボタン非表示
+    mapTypeControl: false, // 地図、航空写真のボタン非表示
+    fullscreenControl: false, // フルスクリーンボタン非表示
+  });
+
+  // マップのドラッグ終了イベント
+  map.addListener("dragend", function () {
+    lastCenter = map.getCenter();
+    lastZoom = map.getZoom();
+    console.log("ドラッグ後座標：", lastCenter.lat(), lastCenter.lng());
+  });
+
+  // infoWindowを作成
+  infoWindow = new google.maps.InfoWindow({
+    pixelOffset: new google.maps.Size(0, -50),
+    maxWidth: 300,
+  });
 
   switch (mode) {
     case "currentLocation":


### PR DESCRIPTION
## 概要

lastZoom値が変更された状態でトップページから現在地取得を行ったとき、遷移後の地図のズームレベルがlastZoomの値を参照してしまい、状況によって同じ結果が得られないため、現在地取得のときはズームレベルが固定値となるように修正

## 変更点

- modified:   app/javascript/gmap.js
  - modeの条件分岐と代入タイミングをmap生成より先行するように変更
  - map生成時のズームレベルの条件を変更
    - modeがcurrentLocationのとき
      zoom: 15
    - modeがcurrentLocation以外でlastZoomが存在するとき
      zoom: lastZoom
    - modeがcurrentLocation以外でlastZoomが存在しないとき
      zoom: 15

## 影響範囲

現在地取得時の地図のズームレベルが常に固定値になる

## テスト

- localhostで動作を確認
  - 検索後ズームレベルが変更された状態でトップページから現在地取得を行い、ズームレベルが継承されていないことを確認
  - リセット動作後ズームレベルが変更された状態でトップページから現在地取得を行い、ズームレベルが継承されていないことを確認
  - ドラッグ手動ズーム後ズームレベルが変更された状態でトップページから現在地取得を行い、ズームレベルが継承されていないことを確認

## 関連Issue

- 関連Issue: #114