### PR TITLE
update: 絞り込み検索フォームの修正（一部ワード検索フォーム含む）

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -243,3 +243,19 @@ body {
   border-color: #8F7C68;
   box-shadow: 0 0 5px rgba(143, 124, 104, 0.5);
 }
+
+.dropdown-menu .btn-clear {
+  background-color: #fff;
+  border: 2px solid #A9907E;
+  color: #A9907E;
+  height: 40px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.dropdown-menu .btn-clear:hover {
+  background-color: #8F7C68;
+  color: #EDE8E2;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,11 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll("input[type='number']").forEach((input) => {
+    input.addEventListener("input", function () {
+      if (this.value < 0) this.value = 0; // 0 未満の値を入力できないようにする
+    });
+  });
+});

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,3 +10,14 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+
+document.addEventListener("DOMContentLoaded", function () {
+  const resetButton = document.getElementById("reset-button");
+
+  if (resetButton) {
+    resetButton.addEventListener("click", function () {
+      document.getElementById("rating_form").value = "";
+      document.getElementById("user_ratings_total_form").value = "";
+    });
+  }
+});

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,6 +3,7 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
 
+// 絞り込み検索フォームにマイナスの値が入力されたら「０」を返す
 document.addEventListener("DOMContentLoaded", function () {
   document.querySelectorAll("input[type='number']").forEach((input) => {
     input.addEventListener("input", function () {
@@ -11,6 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
+// 絞り込み検索のドロップダウン内のクリアボタンを押すと、フォームがクリアされる
 document.addEventListener("DOMContentLoaded", function () {
   const resetButton = document.getElementById("reset-button");
 
@@ -20,4 +22,16 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("user_ratings_total_form").value = "";
     });
   }
+});
+
+// 入力値のあるフォームを選択したときに入力値をハイライトする
+document.addEventListener("DOMContentLoaded", function () {
+  // フォーム要素を取得
+  const inputFields = document.querySelectorAll(".auto-select");
+
+  inputFields.forEach((input) => {
+    input.addEventListener("focus", function () {
+      this.select(); // フォームの中身を全選択
+    });
+  });
 });

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -20,18 +20,24 @@
       <!-- 絞り込みフォーム（ドロップダウンの中） -->
       <div class="dropdown-menu p-4" style="min-width: 250px;">
         <div class="mb-3">
-          <%= f.label :rating_gteq, "評価" %>
+          <%= f.label :rating, "評価" %>
           <div class="input-group">
-            <%= f.number_field :rating_gteq, class: "form-control", step: "0.1", placeholder: "例: 4.0" %>
+            <%= f.number_field :rating_gteq, class: "form-control", id: "rating_form", step: "0.1", placeholder: "例: 4.0" %>
             <span class="input-group-text">以上</span>
           </div>
         </div>
 
-        <%= f.label :user_ratings_total_gteq, "コメント数" %>
+        <%= f.label :user_ratings_total, "評価数" %>
         <div class="input-group">
-          <%= f.number_field :user_ratings_total_gteq, class: "form-control", placeholder: "例: 50" %>
+          <%= f.number_field :user_ratings_total_gteq, class: "form-control", id: "user_ratings_total_form", placeholder: "例: 50" %>
           <span class="input-group-text">以上</span>
         </div>
+
+        <!-- リセットボタン -->
+        <div class="d-flex justify-content-end">
+          <button type="button" class="btn btn-clear mt-3" id="reset-button">クリア</button>
+        </div>
+
       </div>
     </div>
     <% end %>
@@ -41,7 +47,7 @@
   <% if current_page?(bagel_shops_path) %>
   <div class="sort-links-container">
     <%= sort_link(@q, :rating, '評価順', default_order: :desc) %>
-    <%= sort_link(@q, :user_ratings_total, 'コメント数順', default_order: :desc) %>
+    <%= sort_link(@q, :user_ratings_total, '評価数順', default_order: :desc) %>
     <!-- <%= sort_link(@q, :distance, '距離順') %> </div> -->
   </div>
   <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -3,7 +3,7 @@
   <%= search_form_for @q, url: bagel_shops_path, method: :get, data: { turbo: false } do |f| %>
   <div class="search-form-container d-flex align-items-center">
     <div class="input-group">
-      <%= f.search_field :address_or_name_cont, class: 'form-control', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
+      <%= f.search_field :address_or_name_cont, class: 'form-control auto-select', placeholder: "店舗名、地名で検索", id: 'name_or_address' %>
       <div class="input-group-append">
         <%= button_tag type: 'submit', class: 'btn btn-primary', name: 'search_button' do %>
         <i class="fa-solid fa-magnifying-glass"></i>
@@ -22,14 +22,14 @@
         <div class="mb-3">
           <%= f.label :rating, "評価" %>
           <div class="input-group">
-            <%= f.number_field :rating_gteq, class: "form-control", id: "rating_form", step: "0.1", placeholder: "例: 4.0" %>
+            <%= f.number_field :rating_gteq, class: "form-control auto-select", id: "rating_form", step: "0.1", placeholder: "例: 4.0" %>
             <span class="input-group-text">以上</span>
           </div>
         </div>
 
         <%= f.label :user_ratings_total, "評価数" %>
         <div class="input-group">
-          <%= f.number_field :user_ratings_total_gteq, class: "form-control", id: "user_ratings_total_form", placeholder: "例: 50" %>
+          <%= f.number_field :user_ratings_total_gteq, class: "form-control auto-select", id: "user_ratings_total_form", placeholder: "例: 50" %>
           <span class="input-group-text">以上</span>
         </div>
 


### PR DESCRIPTION
## 概要

絞り込み検索フォーム（一部ワード検索フォームを含む）の以下の点を調整
- マイナス入力を制限
- 入力クリアボタンの設置
- 入力値がフォームにあるときはフォーム選択時にハイライト

## 変更点

- modified:   app/assets/stylesheets/application.bootstrap.scss
  - クリアボタンのスタイル調整
- modified:   app/javascript/application.js
  下記イベントを追加
  - マイナス入力を制限
  - 入力クリアボタンの設置
  - 入力値がフォームにあるときはフォーム選択時にハイライト（ワード検索にも適用）
- modified:   app/views/shared/_search_form.html.erb
  - 上記イベントのid設定

## 影響範囲

検索動作の不快感が軽減される

## テスト

- localhostで挙動を確認
  - マイナス入力を制限されているのを確認
  - 入力クリアボタンが設置され、ボタンで絞り込み検索の入力がクリアされることを確認
  - 入力値がフォームにあるときに、フォームを選択して入力値がハイライトされるのを確認

## 関連Issue

- 関連Issue: #113 