### PR TITLE
fix: 絞り込み検索時に地図の挙動が現在地取得の条件で実行されているのを修正 + infoWindowの表示の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,22 +4,20 @@ class ApplicationController < ActionController::Base
 
   def set_search
     @q = BagelShop.ransack(params[:q])
+    search_bagel_shops = @q.result(distinct: true)
     @bagel_shops = @q.result(distinct: true).page(params[:page])
 
     if params[:q].present?
-      # gonのキャッシュを防ぐため、明示的にリセット
-      gon.clear
-      gon.search_bagel_shops = @bagel_shops
+      gon.clear # gonのキャッシュを防ぐため、明示的にリセット
+      gon.search_bagel_shops = search_bagel_shops
     end
-
-    # puts "gon.search_bagel_shops: #{@bagel_shops.inspect}"
 
     return unless params[:search_button]
 
-    if params[:q][:address_or_name_cont].blank? && params[:q][:rating_gteq].blank? && params[:q][:user_ratings_total_gteq].blank?
-      flash[:warning] = '検索ワードが入力されていません'
+    if params[:q][:address_or_name_cont].blank? && params[:q][:rating_gteq].blank? && params[:q][:user_ratings_total_gteq].blank? # 検索フォームに入力があったら
+      flash[:warning] = '検索フォームが入力されていません'
       redirect_back(fallback_location: root_path)
-    elsif @bagel_shops.empty?
+    elsif @bagel_shops.empty? # 検索結果がなかったら
       flash[:warning] = '検索結果が見つかりませんでした'
       redirect_back(fallback_location: root_path)
     end

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -48,17 +48,18 @@ function initMap() {
   loadingElement.style.display = "flex";
 
   // 地図に表示する店舗の条件分岐
+
+  console.log("search_bagel_shops:", gon.search_bagel_shops);
+
   if (
-    !document.getElementById("name_or_address").value &&
-    !gon.reset_button_clicked
+    !gon.search_bagel_shops && !gon.reset_button_clicked
   ) {
-    mode = "currentLocation"; // ①検索ワードなし、リセットfalse
+    mode = "currentLocation"; // ①検索結果なし、リセットfalse
     console.log("mode：", mode);
   } else if (
-    document.getElementById("name_or_address").value &&
-    !gon.reset_button_clicked
+    gon.search_bagel_shops && !gon.reset_button_clicked
   ) {
-    mode = "wordSearch"; // ②検索ワードあり、リセットfalse
+    mode = "search"; // ②検索結果あり、リセットfalse
     console.log("mode：", mode);
   } else {
     mode = "reset"; // ③リセットtrue
@@ -94,6 +95,8 @@ function initMap() {
     pixelOffset: new google.maps.Size(0, -50),
     maxWidth: 300,
   });
+
+  console.log("search_bagel_shops:", gon.search_bagel_shops)
 
   switch (mode) {
     case "currentLocation":
@@ -148,7 +151,9 @@ function initMap() {
               <div class="custom-info-item name">${shop.name}</div>
               <div class="custom-info-item address">${shop.address}</div>
               <div class="custom-info-item rating">⭐${
-                shop.rating ? shop.rating : "評価なし"
+                shop.rating
+                  ? `${shop.rating} (${shop.user_ratings_total})`
+                  : "評価なし"
               }</div>
                 <div class="custom-info-item link_to_detail">
                 <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
@@ -164,7 +169,9 @@ function initMap() {
             <div class="custom-info-item name">${shop.name}</div>
             <div class="custom-info-item address">${shop.address}</div>
             <div class="custom-info-item rating">⭐${
-              shop.rating ? shop.rating : "評価なし"
+              shop.rating
+                ? `${shop.rating} (${shop.user_ratings_total})`
+                : "評価なし"
             }</div>
               <div class="custom-info-item link_to_detail">
               <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
@@ -179,9 +186,9 @@ function initMap() {
       });
       break;
 
-    case "wordSearch":
-      // ワード検索の場合
-      console.log("ワード検索");
+    case "search":
+      // ワード検索 or 絞り込み検索の場合
+      console.log("ワード検索 or 絞り込み検索");
 
       //検索ワードがある場合
       searchBagelShops = gon.search_bagel_shops || [];
@@ -244,7 +251,9 @@ function initMap() {
               <div class="custom-info-item name">${shop.name}</div>
               <div class="custom-info-item address">${shop.address}</div>
               <div class="custom-info-item rating">⭐${
-                shop.rating ? shop.rating : "評価なし"
+                shop.rating
+                  ? `${shop.rating} (${shop.user_ratings_total})`
+                  : "評価なし"
               }</div>
               <div class="custom-info-item link_to_detail">
               <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
@@ -260,7 +269,9 @@ function initMap() {
               <div class="custom-info-item name">${shop.name}</div>
               <div class="custom-info-item address">${shop.address}</div>
               <div class="custom-info-item rating">⭐${
-                shop.rating ? shop.rating : "評価なし"
+                shop.rating
+                  ? `${shop.rating} (${shop.user_ratings_total})`
+                  : "評価なし"
               }</div>
               <div class="custom-info-item link_to_detail">
               <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
@@ -361,7 +372,9 @@ function initMap() {
               <div class="custom-info-item name">${shop.name}</div>
               <div class="custom-info-item address">${shop.address}</div>
               <div class="custom-info-item rating">⭐${
-                shop.rating ? shop.rating : "評価なし"
+                shop.rating
+                  ? `${shop.rating} (${shop.user_ratings_total})`
+                  : "評価なし"
               }</div>
                 <div class="custom-info-item link_to_detail">
                 <a href="/bagel_shops/${shop.id}" >店舗詳細</a>
@@ -377,7 +390,9 @@ function initMap() {
             <div class="custom-info-item name">${shop.name}</div>
             <div class="custom-info-item address">${shop.address}</div>
             <div class="custom-info-item rating">⭐${
-              shop.rating ? shop.rating : "評価なし"
+              shop.rating
+                ? `${shop.rating} (${shop.user_ratings_total})`
+                : "評価なし"
             }</div>
               <div class="custom-info-item link_to_detail">
               <a href="/bagel_shops/${shop.id}" >店舗詳細</a>


### PR DESCRIPTION
## 概要

絞り込み検索時に地図の挙動が現在地取得の条件で実行されているため、条件分岐の記載を修正 + infoWindowの表示に評価数の追加

## 変更点

- modified:   app/controllers/application_controller.rb
  - search_bagel_shops変数を定義し、検索結果全てを代入
  - フォームに入力が存在する場合はこのsearch_bagel_shopsの値をgonで渡す
  - フラッシュメッセージの文言修正
- modified:   app/javascript/gmap.js
  - case wordSearchをcase searchに変更
  - ワード検索フォームの入力値を判断材料にしていたものを検索結果が存在することを判断材料に変更
  - infoWindowの記載に評価数の追記

## 影響範囲

絞り込み検索のみのときに検索結果が全て含まれるようにズームレベルを調節し、地図に全ての検索結果のピンが立つようになる

## テスト

- localhostで挙動を確認
  - 絞り込み検索のみ実行したときに現在地取得されないことを確認
  - 地図に一覧と同じ全ての検索結果のピンが表示されているのを確認
  - 地図のズームレベルが調節されるのを確認

## 関連Issue

- 関連Issue: #117