### PR TITLE
fix: プライバシー・ポリシーページの問い合わせへのリンク設定を修正

### DIFF
--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -52,7 +52,7 @@
     <p>本ポリシーの内容は、法令やサービスの変更により適宜修正されます。修正後は本サイトに掲示された時点で効力を発生します。</p>
 
     <h3 class="mt-4">第10条（お問い合わせ）</h3>
-    <p>本ポリシーに関するお問い合わせは、<a href="https://forms.gle/your-google-form-link" target="_blank">こちらのフォーム</a>からお願いいたします。</p>
+    <p>本ポリシーに関するお問い合わせは、<%= link_to 'こちらのフォーム', 'https://forms.gle/wbYBH7aVzKSNTFGx9', target: :_blank, rel: "noopener noreferrer" %>からお願いいたします。</p>
   </div>
 
   <div class="text-center mt-5">


### PR DESCRIPTION
## 概要

プライバシー・ポリシーのページに記載されている問い合わせへのリンク先が設定されていなかったので修正

## 変更点

- modified:   app/views/static_pages/privacy_policy.html.erb
  - aタグをlink_toに変更し、リンク先を設定

## 影響範囲

プライバシー・ポリシーのページに記載されている問い合わせへのリンクから別タブで問い合わせページを表示できる

## テスト

- localhostで挙動を確認
  - プライバシー・ポリシーページのリンクから別ダブで問い合わせページが展開されるのを確認

## 関連Issue

- 関連Issue: #123 