### PR TITLE
add: 店舗画像の取得時にブラウザキャッシュを積極的に使用するように変更

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -8,13 +8,21 @@ class PhotosController < ApplicationController
 
     begin
       image = URI.open(url)
+
+      # 1日の間、キャッシュに保持する
+      expires_in 1.days, public: true
+
       send_data image.read, type: image.content_type, disposition: 'inline'
+
     rescue OpenURI::HTTPError => e
       # エラーログを出力
       Rails.logger.error "Photo API error: #{e.message}"
       Rails.logger.error "URL attempted: #{url}"
 
-      # 代替画像を表示（public/images/no_image.pngを用意しておくと安心）
+      # 1日の間、キャッシュに保持する
+      expires_in 1.days, public: true
+
+      # 代替画像を表示
       fallback_path = Rails.root.join('public', 'images', 'no_image.jpg')
       send_file fallback_path, type: 'image/jpg', disposition: 'inline'
     end


### PR DESCRIPTION
## 概要

店舗画像の読み込みが発生するごとにAPIにアクセスするため、１日の間はブラウザキャッシュから店舗画像を再取得するように変更

## 変更点

- modified:   app/controllers/photos_controller.rb
  - expires_in 1.days, public: trueを追記

## 影響範囲

店舗画像を表示するindex、showページの画像表示方法が変更

## テスト

- localhostで挙動を確認
  - 今まで通り表示されるのを確認
  - 開発者ツールのネットワーク
    - 画像のレスポンスヘッダーの cache-control が max-age=86400, public となっていることを確認

## 関連Issue

- 関連Issue: #128 