### PR TITLE
add: 店舗一覧の画像取得を遅延読み込みするように変更

### DIFF
--- a/app/views/bagel_shops/_shop_list.html.erb
+++ b/app/views/bagel_shops/_shop_list.html.erb
@@ -2,10 +2,7 @@
   <div id="bagel_shop-id-<% bagel_shop.id %>">
     <div class="card">
       <% if bagel_shop.photo_references.present? %>
-      <%= image_tag place_photo_path(ref: bagel_shop.photo_references.split(",").first), alt: bagel_shop.name, class: "card-img-top", width: "300", height:"300", style: "object-fit: cover;" %>
-      <!--
-      <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=#{bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: bagel_shop.name, class: "card-img-top", width: "300", height:"300", style: "object-fit: cover;" %>
-      -->
+      <%= image_tag place_photo_path(ref: bagel_shop.photo_references.split(",").first), alt: bagel_shop.name, class: "card-img-top", width: "300", height:"300", style: "object-fit: cover;", loading: "lazy" %>
       <% else %>
       <%= image_tag "bagel_shop_placeholder.jpg", class: "card-img-top", width: "300", height: "300", style: "object-fit: cover;" %>
       <% end %>

--- a/app/views/bagel_shops/show.html.erb
+++ b/app/views/bagel_shops/show.html.erb
@@ -10,9 +10,6 @@
       <div class="card mb-4">
         <% if @bagel_shop.photo_references.present? %>
         <%= image_tag place_photo_path(ref: @bagel_shop.photo_references.split(",").first), alt: @bagel_shop.name, class: "card-img-top shop-image", width: "400", height: "400", style: "object-fit: cover;" %>
-        <!--
-        <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=#{@bagel_shop.photo_references.split(",").first}&key=#{ENV['GMAPS_API_KEY']}", alt: @bagel_shop.name, size: "400x400", class: "card-img-top shop-image", style: "object-fit: cover;" %>
-        -->
         <% else %>
         <%= image_tag "bagel_shop_placeholder.jpg", class: "card-img-top shop-image", width: "400", height: "400", style: "object-fit: cover;" %>
         <% end %>


### PR DESCRIPTION
## 概要

index（店舗一覧）ページの店舗画像取得に遅延読み込みを実装

## 変更点

- modified:   app/views/bagel_shops/_shop_list.html.erb
  - image_tagに loading: "lazy" を追記
  - コメントアウトしていた過去のコード（消し忘れ）を削除
- modified:   app/views/bagel_shops/show.html.erb
  - コメントアウトしていた過去のコード（消し忘れ）を削除

## 影響範囲

index（店舗一覧）ページの店舗画像が遅延読み込みされる

## テスト

- localhostで挙動を確認
  - 開発者ツールのネットワーク
    - ページのスクロールに合わせて一覧表示の画像が読み込まれているのを確認

## 関連Issue

- 関連Issue: #132 