### PR TITLE
hotfix: Places APIのアクセスが多く、課金が発生しているためキャッシュの有効期間を30日に変更

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -9,8 +9,8 @@ class PhotosController < ApplicationController
     begin
       image = URI.open(url)
 
-      # 1日の間、キャッシュに保持する
-      expires_in 1.days, public: true
+      # 30日の間、キャッシュに保持する
+      expires_in 30.days, public: true
 
       send_data image.read, type: image.content_type, disposition: 'inline'
 
@@ -19,8 +19,8 @@ class PhotosController < ApplicationController
       Rails.logger.error "Photo API error: #{e.message}"
       Rails.logger.error "URL attempted: #{url}"
 
-      # 1日の間、キャッシュに保持する
-      expires_in 1.days, public: true
+      # 30日の間、キャッシュに保持する
+      expires_in 30.days, public: true
 
       # 代替画像を表示
       fallback_path = Rails.root.join('public', 'images', 'no_image.jpg')


### PR DESCRIPTION
## 概要

Places APIのアクセスが多く、課金が発生しているためキャッシュの有効期間を30日に変更

## 変更点

- modified:   app/controllers/photos_controller.rb
  - expires_inの有効期間を30日に変更

## 影響範囲

店舗画像取得時にPlaces APIにアクセスせずにキャッシュからデータを持ってくる期間が長くなる

## テスト

- localhostで挙動を確認
  - レスポンスヘッダー
    - 取得した画像のmax-ageが2592000に鳴っているのを確認

## 関連Issue

- 関連Issue: #128 